### PR TITLE
updated find_user_shibboleth to concatenate email from uid when email…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,7 @@ class User < ActiveRecord::Base
     if auth_hash.uid.blank?
       raise Avalon::MissingUserId 
     end
+    email = auth_hash.info.email || auth_hash.uid + "@ualberta.ca"
     
     result = 
       User.find_by_username(auth_hash.uid) ||


### PR DESCRIPTION
… info is missing

In test environment, email is an attribute that is missing from the shibboleth response. This is to make sure that if the information is missing, we are still enble to register users with proper email addresses. 