### PR TITLE
The collection on the Avalon homepage was mispelled. As per Sean's re…

### DIFF
--- a/app/views/catalog/_home.html.erb
+++ b/app/views/catalog/_home.html.erb
@@ -85,7 +85,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <div class="col-sm-4">
       <a href="/catalog?q=Nosotros+Television+Programme" class="featured"> 
         <h3><em>Featured Collection</em></h3>
-        <h2>Nostros Television</h2>
+        <h2>Nosotros Television Programme</h2>
       </a>
     </div>
   </div>


### PR DESCRIPTION
The collection on the Avalon homepage was mispelled. As per Sean's request,
also include the word "Programme" which is in the collection's name.
