### PR TITLE
The styling of opacity of the front page videos was too loose,

### DIFF
--- a/app/assets/stylesheets/era_custom.css.scss
+++ b/app/assets/stylesheets/era_custom.css.scss
@@ -1361,7 +1361,7 @@ span.tooltip-label-required {
 .eraav-content {
   margin: -10px 20px 0px 20px;
 }
-video {
+.banner-video video {
   opacity: 0.3;
 }
 .glyphicon-plus {


### PR DESCRIPTION
which made all videos look dim on Safari. Ensure the style only
applies to a child of the banner-video class.

Fixes #247 
