### PR TITLE
Fix eClass token authorization refresh code

### DIFF
--- a/app/assets/javascripts/refresh_token.js.coffee
+++ b/app/assets/javascripts/refresh_token.js.coffee
@@ -1,9 +1,10 @@
 $ ->
   refreshToken = ->
-    mount_point = $('body').data('mountpoint')
-    token = currentPlayer.sources.context.src.split('?')[1]
-    $.get("#{mount_point}authorize.txt?#{token}")
-      .done -> console.log("Token refreshed")
-      .fail -> console.error("Token refresh failed")
+    token = currentPlayer.media.src.split('?')[1]
+    if token && token.match(/^token=/)
+      mount_point = $('body').data('mountpoint') || '/'
+      $.get("#{mount_point}authorize.txt?#{token}")
+        .done -> console.log("Token refreshed")
+        .fail -> console.error("Token refresh failed")
 
   setInterval(refreshToken, 5*60*1000)

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -264,7 +264,7 @@ class MasterFile < ActiveFedora::Base
       if self.permalink
         url = self.permalink(permalink_opts)
       else
-        url = embed_master_file_path(self.pid, only_path: false, protocol: '//')
+        url = embed_master_file_path(self.pid, only_path: false, protocol: 'https://')
       end
       height = is_video? ? (width/display_aspect_ratio.to_f).floor : AUDIO_HEIGHT
       "<iframe title=\"#{ embed_title }\" src=\"#{url}\" width=\"#{width}\" height=\"#{height}\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"

--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -26,7 +26,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     
   </head>
 
-  <body>
+  <body data-mountpoint="<%= root_path %>">
     <%= yield %>
 
     <!-- With this many Javascript files performance will be much better


### PR DESCRIPTION
So that rollbar doesn't get a thousand errors a day.

Here's what the errors look like: https://rollbar.com/ualbertalib/avalon/items/7/

The javascript now handles errors better. Most of this is based on a fix in upstream avalon:

https://github.com/avalonmediasystem/avalon/blob/master/app/assets/javascripts/refresh_token.js.coffee

Also included a fix to the 'Share / Embed' view, not showing a correct network protocol for the iframe embed code it provides to the user.