### PR TITLE
Address security issues reported by Gemnasium.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@
   # Some package upgrades related to Gemnasium alerts
   gem 'mail', '~> 2.6.6.rc1'
   # pin this to post-USN-3424-1
-  gem 'nokogiri', '~> 1.8.1'
+  gem 'nokogiri', '~> 1.8.2'
 
 #  gem 'hydra', '~>8.0'
   gem 'hydra-head', git: 'https://github.com/avalonmediasystem/hydra-head.git', branch: '8-1-stable'
@@ -87,7 +87,8 @@
   gem 'active_encode', git: "https://github.com/projecthydra-labs/active_encode.git", tag: 'v0.0.3'
   gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git"
   gem 'validates_email_format_of'
-  gem 'loofah'
+  gem 'loofah', '~> 2.2.1'
+  gem 'rails-html-sanitizer', '~> 1.0.4'
   gem 'omniauth-identity'
   gem 'omniauth-lti', git: "https://github.com/avalonmediasystem/omniauth-lti.git", tag: 'avalon-r4'
   gem 'omniauth-shibboleth'
@@ -99,7 +100,7 @@
   gem 'with_locking'
 
   gem 'equivalent-xml'
-  gem 'net-ldap'
+  gem 'net-ldap', '~> 0.16.0'
 
   gem 'api-pagination'
   gem 'avalon-wowza'
@@ -133,7 +134,7 @@
     gem 'meta_request'
     gem 'capistrano', '~>2.12.0'
     gem 'rvm-capistrano', require: false
-    gem 'rubocop', '~> 0.40.0', require: false
+    gem 'rubocop', '~> 0.49.1', require: false
     gem 'rugged'
     gem 'web-console', '~> 2.0'
   end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     api-pagination (4.5.2)
     arel (6.0.4)
-    ast (2.3.0)
+    ast (2.4.0)
     autoprefixer-rails (6.6.1)
       execjs
     avalon-wowza (0.2.0)
@@ -347,7 +347,7 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6)
-    crass (1.0.2)
+    crass (1.0.4)
     daemons (1.2.4)
     debug_inspector (0.0.2)
     debugger (1.6.8)
@@ -517,7 +517,7 @@ GEM
     logging (2.1.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.1.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -547,7 +547,7 @@ GEM
     mysql2 (0.3.21)
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
-    net-ldap (0.15.0)
+    net-ldap (0.16.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -556,7 +556,7 @@ GEM
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     netrc (0.11.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)
@@ -584,8 +584,9 @@ GEM
       omniauth (>= 1.0.0)
     orm_adapter (0.5.0)
     os (0.9.6)
-    parser (2.3.3.1)
-      ast (~> 2.2)
+    parallel (1.12.1)
+    parser (2.5.0.5)
+      ast (~> 2.4.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -624,14 +625,15 @@ GEM
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (4.2.9)
       actionpack (= 4.2.9)
       activesupport (= 4.2.9)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.1)
+    rainbow (2.2.2)
+      rake
     rake (10.5.0)
     rb-fsevent (0.9.8)
     rdf (1.1.17.1)
@@ -722,8 +724,9 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.40.0)
-      parser (>= 2.3.1.0, < 3.0)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -738,7 +741,7 @@ GEM
       i18n
       iso8601
     ruby-ole (1.2.12)
-    ruby-progressbar (1.8.1)
+    ruby-progressbar (1.9.0)
     rubydora (1.8.1)
       activemodel
       activesupport
@@ -829,7 +832,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
-    unicode-display_width (1.1.3)
+    unicode-display_width (1.3.0)
     validates_email_format_of (1.6.3)
       i18n
     warden (1.2.7)
@@ -908,7 +911,7 @@ DEPENDENCIES
   letter_opener
   levenshtein
   license_header
-  loofah
+  loofah (~> 2.2.1)
   mail (~> 2.6.6.rc1)
   marc
   media-element-logo-plugin
@@ -926,8 +929,8 @@ DEPENDENCIES
   modal_logic!
   multipart-post
   mysql2 (~> 0.3.20)
-  net-ldap
-  nokogiri (~> 1.8.1)
+  net-ldap (~> 0.16.0)
+  nokogiri (~> 1.8.2)
   nom-xml (~> 0.5.2)
   om (~> 3.1.0)
   omniauth-identity
@@ -939,6 +942,7 @@ DEPENDENCIES
   pry-rails
   puma
   rails (~> 4.2)
+  rails-html-sanitizer (~> 1.0.4)
   rake (~> 10.4)
   rb-fsevent (~> 0.9.1)
   red5wrapper!
@@ -948,7 +952,7 @@ DEPENDENCIES
   rspec-its
   rspec-rails
   rspec_junit_formatter
-  rubocop (~> 0.40.0)
+  rubocop (~> 0.49.1)
   ruby-duration
   rubydora (~> 1.8.1)
   rubyhorn!


### PR DESCRIPTION
In particular, Gemnasium wants:

loofah >= 2.2.1
net-ldap >= 0.16.0
nokogiri >= 1.8.2
rails-html-sanitizer >= 1.0.4
rubocop >= 0.49.1
