### PR TITLE
Make Avalon docker look more like Jupiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ vendor/bundle
 config/authentication.yml
 config/avalon.yml
 config/controlled_vocabulary.yml
-config/matterhorn.yml
 config/role_map_development.yml
 config/initializers/rubyhorn.rb
 config/secrets.yml

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ config/avalon.yml
 config/controlled_vocabulary.yml
 config/role_map_development.yml
 config/initializers/rubyhorn.rb
-config/secrets.yml
 #config/lti.yml
 
 public/media_objects

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ git:
   submodules: false
 bundler_args: --with postgres aws --without development debug
 env:
-  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test DATABASE_URL=postgresql://postgres:@127.0.0.1:5432/
+  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_TEST_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test DATABASE_URL=postgresql://postgres:@127.0.0.1:5432/
 services:
   - mysql2
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ before_install:
   - cp config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
   - bundle config without development:production
 before_script:
-  - rm config/database.yml
-  - cp config/database.travis.yml config/database.yml
-  - psql -c 'create database travis_ci_test;' -U postgres
+  - bundle exec rake db:create
   - bundle exec rake db:migrate
 script:
   - bundle exec rake
@@ -26,7 +24,7 @@ language: ruby
 jdk:
   - oraclejdk8
 rvm:
-  - 2.3
   - 2.4
+  - 2.5
 dist: trusty
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ git:
   submodules: false
 bundler_args: --with postgres aws --without development debug
 env:
-  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test
+  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test DATABASE_URL=postgresql://avalon:mysecretpassword@db:5432/
 services:
   - mysql2
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 git:
   submodules: false
 bundler_args: --with postgres aws --without development debug
+env:
+  - FCREPO_URL=http://127.0.0.1:8986/rest
+  - SOLR_URL=http://127.0.0.1:8985/solr/hydra-test
+  - RAILS_ENV=test
 services:
   - mysql2
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ git:
   submodules: false
 bundler_args: --with postgres aws --without development debug
 env:
-  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test DATABASE_URL=postgresql://avalon:mysecretpassword@db:5432/
+  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test DATABASE_URL=postgresql://postgres:@127.0.0.1:5432/
 services:
   - mysql2
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ git:
   submodules: false
 bundler_args: --with postgres aws --without development debug
 env:
-  - FCREPO_URL=http://127.0.0.1:8986/rest
-  - SOLR_URL=http://127.0.0.1:8985/solr/hydra-test
-  - RAILS_ENV=test
+  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test
 services:
   - mysql2
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,8 @@ before_script:
   - cp config/database.travis.yml config/database.yml
   - psql -c 'create database travis_ci_test;' -U postgres
   - bundle exec rake db:migrate
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
 script:
   - bundle exec rake
-after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 language: ruby
 jdk:
   - oraclejdk8

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'speedy-af', '~> 0.1.1'
 gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", tag: 'avalon-r6.2'
 
 # Authentication & Authorization
-gem 'devise'
+gem 'devise', '~> 4.4'
 gem 'ims-lti', '~> 1.1.13'
 gem 'net-ldap'
 gem 'omniauth-identity'

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'browse-everything', '~> 0.13.0'
 gem 'mediainfo', git: "https://github.com/avalonmediasystem/mediainfo.git", branch: 'avalon_fixes'
 gem 'rest-client'
 gem 'roo'
-gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git", tag: 'avalon-r6'
+gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git", ref: '57c12f23344d8015e223bd36e2544f98fb3a672d'
 
 # Data Translation & Normalization
 gem 'edtf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,8 +101,8 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/rubyhorn.git
-  revision: fd1e0ee2cca53df515f58690603e9a6351066106
-  tag: avalon-r6
+  revision: 57c12f23344d8015e223bd36e2544f98fb3a672d
+  ref: 57c12f23344d8015e223bd36e2544f98fb3a672d
   specs:
     rubyhorn (0.0.6)
       activesupport

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    bcrypt (3.1.11)
+    bcrypt (3.1.12)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
     binding_of_caller (0.7.2)
@@ -324,7 +324,7 @@ GEM
       deep_merge (~> 1.1.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.3)
+    crass (1.0.4)
     daemons (1.2.4)
     dalli (2.7.6)
     database_cleaner (1.6.1)
@@ -334,10 +334,10 @@ GEM
     deep_merge (1.1.1)
     deprecation (1.0.0)
       activesupport
-    devise (4.3.0)
+    devise (4.4.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 5.2)
+      railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
@@ -441,7 +441,7 @@ GEM
       hydra-access-controls (= 10.3.4)
       hydra-core (= 10.3.4)
       rails (>= 3.2.6)
-    i18n (0.9.1)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     iconv (1.0.4)
     ims-lti (1.1.13)
@@ -497,7 +497,7 @@ GEM
       activesupport (>= 4, < 5.2)
       railties (>= 4, < 5.2)
       request_store (~> 1.0)
-    loofah (2.2.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -516,7 +516,7 @@ GEM
     mimemagic (0.3.2)
     mini_mime (0.1.4)
     mini_portile2 (2.3.0)
-    minitest (5.11.0)
+    minitest (5.11.3)
     mono_logger (1.1.0)
     msgpack (1.2.0)
     multi_json (1.12.2)
@@ -574,7 +574,7 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.0)
-    rack (1.6.9)
+    rack (1.6.10)
     rack-protection (1.5.5)
       rack
     rack-test (0.6.3)
@@ -596,8 +596,8 @@ GEM
       activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (4.2.9)
       actionpack (= 4.2.9)
       activesupport (= 4.2.9)
@@ -605,7 +605,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.3.0)
+    rake (12.3.1)
     rb-readline (0.5.5)
     rchardet (1.6.1)
     rdf (2.2.10)
@@ -802,7 +802,7 @@ GEM
       actionpack (>= 3.1)
       jquery-rails
       railties (>= 3.1)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.0.15)
     uglifier (3.2.0)
@@ -875,7 +875,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   config
   database_cleaner
-  devise
+  devise (~> 4.4)
   dotenv-rails
   edtf
   email_spec

--- a/bin/docker-start
+++ b/bin/docker-start
@@ -14,15 +14,18 @@ cd /home/app/avalon
 
 export HOME=/home/app
 bundle config build.nokogiri --use-system-libraries && \
-bundle install --path=/home/app/gems --with postgres
+bundle install --path=/home/app/gems --with postgres aws test
 
 cp config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
 
+bundle exec rake db:create
+
 if [[ "$RAILS_ENV" =~ ^(production|uat|staging)$ ]]; then
   bundle exec rake assets:precompile
+elif [[ "$RAILS_ENV" = "development" ]]; then
+  RAILS_ENV=test bundle exec rake db:create
 fi
 
-bundle exec rake db:create
 bundle exec rake db:migrate
 
 rm -rf tmp/pids/server.pid

--- a/bin/docker-start
+++ b/bin/docker-start
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+cd /home/app/avalon
+
+# TODO: Avalon image doesn't have nc installed. The bundle install takes enough time
+# that we don't have to wait here for the database anyways.
+# We will probably migrate to Jupiter's docker image instead, which will require:
+
+#while ! nc -z postgres 5432; do
+#  echo "Waiting for database to be available..."
+#  sleep 1
+#done
+
+export HOME=/home/app
+bundle config build.nokogiri --use-system-libraries && \
+bundle install --path=/home/app/gems --with postgres
+
+cp config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
+
+if [[ "$RAILS_ENV" =~ ^(production|uat|staging)$ ]]; then
+  bundle exec rake assets:precompile
+fi
+
+bundle exec rake db:create
+bundle exec rake db:migrate
+
+rm -rf tmp/pids/server.pid
+
+BACKGROUND=yes QUEUE=* bundle exec rake resque:work
+BACKGROUND=yes bundle exec rake environment resque:scheduler
+
+exec bundle exec rails s -p 3000 -b 0.0.0.0

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,10 +1,15 @@
+default: &default
+  adapter: solr
+  url: <%= Rails.application.secrets.solr_url %>
 development:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
-test: &test
+  url: <%= ENV['SOLR_URL'] || 'http://localhost:8983/solr/development' %>
+test:
   adapter: solr
-  url: http://localhost:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/hydra-test
+  url: <%= ENV['SOLR_TEST_URL'] || 'http://localhost:8983/solr/test' %>
+uat:
+  <<: *default
+staging:
+  <<: *default
 production:
-  adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/avalon" %>
-
+  <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,7 +13,9 @@ development:
   database: avalon_development
   # e.g. for connecting with docker image from docker-compose.lightweight.yml:
   #   AVALON_DATABASE_URL=postgresql://avalon:mysecretpassword@127.0.0.1?pool=5
-  url: <%= ENV['AVALON_DATABASE_URL'] || ENV['DATABASE_URL'] %>
+  url: <%= ENV['AVALON_DATABASE_URL'] ||
+           ENV['DATABASE_URL'] ||
+           'postgresql://avalon:mysecretpassword@127.0.0.1?pool=5' %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -27,7 +29,9 @@ test:
   # rails 5 will provision both dev and test database when running db:* rake tasks but it only uses the DATABASE_URL
   # for the dev database. A fix for this is upstream in rails here https://github.com/rails/rails/pull/28933
   # More information can be found here: https://github.com/rails/rails/issues/28827
-  url: <%= ENV['AVALON_DATABASE_URL'] || ENV['DATABASE_URL'] %>
+  url: <%= ENV['AVALON_DATABASE_URL'] ||
+           ENV['DATABASE_URL'] ||
+           'postgresql://avalon:mysecretpassword@127.0.0.1?pool=5' %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,56 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
+# Rails will assume you have a psql superuser matching your system user
+# This may be an issue when using a local postgres instance.
+# configure with:
+# `sudo -u postgres createuser ${USER}`
+# `sudo -u postgres alter user ${USER} superuser
 default: &default
-  adapter: sqlite3
-  pool: 5
-  timeout: 10000
+  adapter: postgresql
+  encoding: utf8
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: avalon_development
+  # e.g. for connecting with docker image from docker-compose.lightweight.yml:
+  #   AVALON_DATABASE_URL=postgresql://avalon:mysecretpassword@127.0.0.1?pool=5
+  url: <%= ENV['AVALON_DATABASE_URL'] || ENV['DATABASE_URL'] %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: avalon_test
 
+  # TODO: Review this later
+  # This is a temporary fix for docker with using DATABASE_URL environment variable,
+  # rails 5 will provision both dev and test database when running db:* rake tasks but it only uses the DATABASE_URL
+  # for the dev database. A fix for this is upstream in rails here https://github.com/rails/rails/pull/28933
+  # More information can be found here: https://github.com/rails/rails/issues/28827
+  url: <%= ENV['AVALON_DATABASE_URL'] || ENV['DATABASE_URL'] %>
+
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%= ENV['DATABASE_URL'] %>
+#
+uat:
+  url: <%= Rails.application.secrets.database_url %>
+staging:
+  url: <%= Rails.application.secrets.database_url %>
 production:
-  <<: *default
-  database: db/production.sqlite3
+  url: <%= Rails.application.secrets.database_url %>

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,15 +1,15 @@
+default: &default
+  user: <%= Rails.application.secrets.fcrepo_user %>
+  password: <%= Rails.application.secrets.fcrepo_password %>
+  url: <%= Rails.application.secrets.fcrepo_url %>
+  base_path: <%= Rails.application.secrets.fcrepo_base_path %>
 development:
-  user: fedoraAdmin
-  password: fedoraAdmin
-  url: http://127.0.0.1:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || 8984 %>/rest
-  base_path: /dev
+  <<: *default
 test:
-  user: fedoraAdmin
-  password: fedoraAdmin
-  url: http://127.0.0.1:<%= ENV['FCREPO_TEST_PORT'] || 8986 %>/rest
-  base_path: /test
+  <<: *default
+uat:
+  <<: *default
+staging:
+  <<: *default
 production:
-  user: fedoraAdmin
-  password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora4/rest
-  base_path: /prod
+  <<: *default

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -1,11 +1,9 @@
 config = Rails.application.config
-
-redis_host = Settings.redis.host
-redis_port = Settings.redis.port || 6379
-config.cache_store = :redis_store, {
-  host: redis_host,
-  port: redis_port,
-  db: 0,
-  namespace: 'avalon'
-}
-
+if ["development", "test"].include?(Rails.env)
+  config.cache_store = :memory_store, { size: 64.megabytes }
+else
+  config.cache_store = :redis_store, {
+    url: Rails.application.secrets.redis_url,
+    namespace: 'avalon'
+  }
+end

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,7 +1,7 @@
 rails_root = ENV['RAILS_ROOT'] || File.dirname(__FILE__) + '/../..'
 rails_env = ENV['RAILS_ENV'] || 'development'
 
-Resque.redis = "#{Settings.redis.host}:#{Settings.redis.port}"
+Resque.redis = Rails.application.secrets.redis_url
 
 # Enable schedule tab in Resque web ui
 require 'resque-scheduler'

--- a/config/matterhorn.yml
+++ b/config/matterhorn.yml
@@ -1,0 +1,10 @@
+development: &default
+  url: <%= Rails.application.secrets.matterhorn_url %>
+test:
+  <<: *default
+uat:
+  <<: *default
+staging:
+  <<: *default
+production:
+  <<: *default

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,12 +10,16 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+shared:
+  redis_url: <%= ENV['REDIS_URL'] %>
+
 development:
   secret_key_base: 8268df0c1b5843bec6d0e6e1095b187766ff6a8f9c1edd4360588d357253fac09c95aebc715f25cb3ecfdf45cfb2da6c1c033149e93a363f3808da67b0b8ab09
   fcrepo_url: <%= ENV['FCREPO_URL'] || 'http://localhost:8984/fcrepo/rest' %>
   fcrepo_user: fedoraAdmin
   fcrepo_password: fedoraAdmin
   fcrepo_base_path: /dev
+  redis_url: <%= ENV['REDIS_URL'] || 'http://localhost:6379' %>
 
 test:
   secret_key_base: f589c05f948f5760c95e5c60fa0fb325a9fa7e8c9ba8190d22b8ff868927215dd4e5252227245dd26b4e98c9441ce5ef34a14ea25b2170191cb3f5ddad6c5755
@@ -23,6 +27,7 @@ test:
   fcrepo_user: fedoraAdmin
   fcrepo_password: fedoraAdmin
   fcrepo_base_path: /test
+  redis_url: <%= ENV['REDIS_URL'] || 'http://localhost:6379' %>
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,6 +12,9 @@
 
 shared:
   redis_url: <%= ENV['REDIS_URL'] %>
+  matterhorn_url: <%= ENV['MATTERHORN_URL'] %>
+  matterhorn_client_media_path: <%= ENV['MATTERHORN_CLIENT_MEDIA_PATH'] %>
+  matterhorn_server_media_path: <%= ENV['MATTERHORN_SERVER_MEDIA_PATH'] %>
 
 development:
   secret_key_base: 8268df0c1b5843bec6d0e6e1095b187766ff6a8f9c1edd4360588d357253fac09c95aebc715f25cb3ecfdf45cfb2da6c1c033149e93a363f3808da67b0b8ab09
@@ -19,7 +22,13 @@ development:
   fcrepo_user: fedoraAdmin
   fcrepo_password: fedoraAdmin
   fcrepo_base_path: /dev
-  redis_url: <%= ENV['REDIS_URL'] || 'http://localhost:6379' %>
+  redis_url: <%= ENV['REDIS_URL'] || 'redis://localhost:6379' %>
+  matterhorn_url: <%= ENV['MATTERHORN_URL'] ||
+                      "http://matterhorn_system_account:CHANGE_ME@localhost:8080/" %>
+  matterhorn_client_media_path: <%= ENV['MATTERHORN_CLIENT_MEDIA_PATH'] ||
+                                    File.join(Rails.root, 'masterfiles') %>
+  matterhorn_server_media_path: <%= ENV['MATTERHORN_SERVER_MEDIA_PATH'] ||
+                                    '/masterfiles' %>
 
 test:
   secret_key_base: f589c05f948f5760c95e5c60fa0fb325a9fa7e8c9ba8190d22b8ff868927215dd4e5252227245dd26b4e98c9441ce5ef34a14ea25b2170191cb3f5ddad6c5755
@@ -27,7 +36,14 @@ test:
   fcrepo_user: fedoraAdmin
   fcrepo_password: fedoraAdmin
   fcrepo_base_path: /test
-  redis_url: <%= ENV['REDIS_URL'] || 'http://localhost:6379' %>
+  redis_url: <%= ENV['REDIS_URL'] || 'redis://localhost:6379' %>
+
+  matterhorn_url: <%= ENV['MATTERHORN_URL'] ||
+                      "http://matterhorn_system_account:CHANGE_ME@localhost:8080/" %>
+  matterhorn_client_media_path: <%= ENV['MATTERHORN_CLIENT_MEDIA_PATH'] ||
+                                    File.join(Rails.root, 'masterfiles') %>
+  matterhorn_server_media_path: <%= ENV['MATTERHORN_SERVER_MEDIA_PATH'] ||
+                                    '/masterfiles' %>
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -29,6 +29,8 @@ test:
 
 uat:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
+  database_url: <%= ENV['DATABASE_URL'] %>
   fcrepo_user: <%= ENV['FCREPO_USER'] %>
   fcrepo_password: <%= ENV['FCREPO_PASSWORD'] %>
   fcrepo_url: <%= ENV['FCREPO_URL'] %>
@@ -37,6 +39,8 @@ uat:
 
 staging:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
+  database_url: <%= ENV['DATABASE_URL'] %>
   fcrepo_user: <%= ENV['FCREPO_USER'] %>
   fcrepo_password: <%= ENV['FCREPO_PASSWORD'] %>
   fcrepo_url: <%= ENV['FCREPO_URL'] %>
@@ -45,6 +49,8 @@ staging:
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
+  database_url: <%= ENV['DATABASE_URL'] %>
   fcrepo_user: <%= ENV['FCREPO_USER'] %>
   fcrepo_password: <%= ENV['FCREPO_PASSWORD'] %>
   fcrepo_url: <%= ENV['FCREPO_URL'] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,7 +19,7 @@ development:
 
 test:
   secret_key_base: f589c05f948f5760c95e5c60fa0fb325a9fa7e8c9ba8190d22b8ff868927215dd4e5252227245dd26b4e98c9441ce5ef34a14ea25b2170191cb3f5ddad6c5755
-  fcrepo_url: <%= ENV['FCREPO_URL'] || 'http://localhost:8080/fcrepo/rest' %>
+  fcrepo_url: <%= ENV['FCREPO_URL'] || 'http://localhost:8984/fcrepo/rest' %>
   fcrepo_user: fedoraAdmin
   fcrepo_password: fedoraAdmin
   fcrepo_base_path: /test

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,11 +12,41 @@
 
 development:
   secret_key_base: 8268df0c1b5843bec6d0e6e1095b187766ff6a8f9c1edd4360588d357253fac09c95aebc715f25cb3ecfdf45cfb2da6c1c033149e93a363f3808da67b0b8ab09
+  fcrepo_url: <%= ENV['FCREPO_URL'] || 'http://localhost:8984/fcrepo/rest' %>
+  fcrepo_user: fedoraAdmin
+  fcrepo_password: fedoraAdmin
+  fcrepo_base_path: /dev
 
 test:
   secret_key_base: f589c05f948f5760c95e5c60fa0fb325a9fa7e8c9ba8190d22b8ff868927215dd4e5252227245dd26b4e98c9441ce5ef34a14ea25b2170191cb3f5ddad6c5755
+  fcrepo_url: <%= ENV['FCREPO_URL'] || 'http://localhost:8080/fcrepo/rest' %>
+  fcrepo_user: fedoraAdmin
+  fcrepo_password: fedoraAdmin
+  fcrepo_base_path: /test
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
+
+uat:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  fcrepo_user: <%= ENV['FCREPO_USER'] %>
+  fcrepo_password: <%= ENV['FCREPO_PASSWORD'] %>
+  fcrepo_url: <%= ENV['FCREPO_URL'] %>
+  fcrepo_base_path: /uat
+  solr_url: <%= ENV['SOLR_URL'] %>
+
+staging:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  fcrepo_user: <%= ENV['FCREPO_USER'] %>
+  fcrepo_password: <%= ENV['FCREPO_PASSWORD'] %>
+  fcrepo_url: <%= ENV['FCREPO_URL'] %>
+  fcrepo_base_path: /staging
+  solr_url: <%= ENV['SOLR_URL'] %>
+
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  fcrepo_user: <%= ENV['FCREPO_USER'] %>
+  fcrepo_password: <%= ENV['FCREPO_PASSWORD'] %>
+  fcrepo_url: <%= ENV['FCREPO_URL'] %>
+  fcrepo_base_path: /prod
+  solr_url: <%= ENV['SOLR_URL'] %>

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,7 +1,13 @@
-# This is a sample config file that points to a solr server for each environment
+# Needed and used by active fedora, to specify where to find solr
+default: &default
+  url: <%= Rails.application.secrets.solr_url %>
 development:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8983 %>/solr/hydra-development
+  url: <%= ENV['SOLR_URL'] || 'http://localhost:8983/solr/development' %>
 test:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/hydra-test
+  url: <%= ENV['SOLR_TEST_URL'] || 'http://localhost:8983/solr/test' %>
+uat:
+  <<: *default
+staging:
+  <<: *default
 production:
-  url: http://127.0.0.1:8983/solr/avalon
+  <<: *default

--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -1,0 +1,65 @@
+version: '3'
+
+volumes:
+  streaming:
+    driver: local
+  database:
+    driver: local
+  fcrepo:
+    driver: local
+  work:
+    driver: local
+  solr:
+    driver: local
+  redis:
+    driver: local
+
+services:
+  db:
+    image: postgres:9.6-alpine
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: mysecretpassword
+      POSTGRES_USER: avalon
+    volumes:
+      - database:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  fcrepo:
+    image: ualbertalib/docker-fcrepo4
+    volumes:
+      - fcrepo:/fcrepo4-data
+    ports:
+      - "8984:8080"
+
+  solr:
+    image: solr:6.6
+    ports:
+      - "8983:8983"
+    volumes:
+      - solr:/opt/solr/server/solr/mycores
+      - ./solr/config:/config
+      - ./solr/scripts/solr-precreate-avalon.sh:/docker-entrypoint-initdb.d/solr-precreate-avalon.sh
+
+  matterhorn:
+    image: avalonmediasystem/matterhorn
+    volumes:
+      - ./masterfiles:/masterfiles
+      - streaming:/streamfiles
+      - work:/work
+    ports:
+      - "8080:8080"
+  hls:
+    image: avalonmediasystem/nginx
+    volumes:
+      - streaming:/data
+    ports:
+       - "8880:80"
+
+  redis:
+    image: redis:alpine
+    volumes:
+      - redis:/data
+    ports:
+      - "6379:6379"

--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -52,6 +52,10 @@ services:
       - "8080:8080"
   hls:
     image: avalonmediasystem/nginx
+    network_mode: "host"
+    environment:
+      AVALON_DOMAIN: http://127.0.0.1:3000
+      AVALON_STREAMING_PORT: 8880
     volumes:
       - streaming:/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 volumes:
   streaming:
   database:
-  fedora:
+  fcrepo:
   work:
   solr:
 
@@ -20,14 +20,13 @@ services:
     ports:
       - "5432:5432"
 
-  fedora:
-    image: avalonmediasystem/fedora:4.7.x
-    depends_on:
-      - db
+  fcrepo:
+    image: ualbertalib/docker-fcrepo4
     volumes:
-      - fedora:/data
+      - fcrepo:/fcrepo4-data
     ports:
       - "8984:8080"
+
   solr:
     image: solr:6.6
     ports:
@@ -60,7 +59,7 @@ services:
     command: "/rails_init-dev.sh"
     depends_on:
       - db
-      - fedora
+      - fcrepo
       - solr
       - redis
     environment:
@@ -76,9 +75,7 @@ services:
       - EMAIL_COMMENTS
       - EMAIL_NOTIFICATION
       - EMAIL_SUPPORT
-      - FEDORA_BASE_PATH
-      - FEDORA_NAMESPACE=avalon
-      - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fedora/rest
+      - FCREPO_URL=http://fcrepo:8080/fcrepo/rest
       - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
       - MASTER_FILE_PATH
       - MASTER_FILE_STRATEGY=delete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,13 @@ volumes:
 
 services:
   db:
-    image: avalonmediasystem/db:fedora4
-    volumes:
-      - database:/data
+    image: postgres:9.6-alpine
     environment:
-      - AVALON_DB_PASSWORD=avalondb
-      - FEDORA_DB_PASSWORD
-      - PGDATA=/data
-      - POSTGRES_USER=postgres
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: mysecretpassword
+      POSTGRES_USER: avalon
+    volumes:
+      - database:/var/lib/postgresql/data
     ports:
       - "5432:5432"
 
@@ -56,7 +55,7 @@ services:
       - "6379:6379"
   avalon:
     image: avalonmediasystem/avalon:6.x-dev
-    command: "/rails_init-dev.sh"
+    command: "/home/app/avalon/bin/docker-start"
     depends_on:
       - db
       - fcrepo
@@ -69,7 +68,7 @@ services:
       - AVALON_DB_PASSWORD=avalondb
       - SETTINGS__DOMAIN=http://localhost:3000
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
-      - DATABASE_URL=postgres://avalon:${AVALON_DB_PASSWORD}@db/avalon
+      - DATABASE_URL=postgresql://avalon:mysecretpassword@db:5432/
       - SETTINGS__DROPBOX__PATH=/masterfiles
       - SETTINGS__DROPBOX__UPLOAD_URI=./masterfiles
       - EMAIL_COMMENTS
@@ -111,6 +110,6 @@ services:
       - ./gems:/gems
       - .:/home/app/avalon
     ports:
-      - "3000:80"
+      - "3000:3000"
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,8 @@ services:
       - MASTER_FILE_PATH
       - MASTER_FILE_STRATEGY=delete
       - MATTERHORN_URL=http://matterhorn_system_account:CHANGE_ME@matterhorn:8080/
-      - SETTINGS__MATTERHORN__MEDIA_PATH=/masterfiles
+      - MATTERHORN_CLIENT_MEDIA_PATH=/masterfiles
+      - MATTERHORN_SERVER_MEDIA_PATH=/masterfiles
       - MEDIAINFO_PATH=/usr/bin/mediainfo
       - RAILS_ENV=development
       - REDIS_URL=redis://redis/90210

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,18 @@
-version: '2'
+version: '3'
 
 volumes:
   streaming:
+    driver: local
   database:
+    driver: local
   fcrepo:
+    driver: local
   work:
+    driver: local
   solr:
+    driver: local
+  redis:
+    driver: local
 
 services:
   db:
@@ -49,10 +56,14 @@ services:
       - streaming:/data
     ports:
        - "8880:80"
+
   redis:
     image: redis:alpine
+    volumes:
+      - redis:/data
     ports:
       - "6379:6379"
+
   avalon:
     image: avalonmediasystem/avalon:6.x-dev
     command: "/home/app/avalon/bin/docker-start"
@@ -82,8 +93,7 @@ services:
       - SETTINGS__MATTERHORN__MEDIA_PATH=/masterfiles
       - MEDIAINFO_PATH=/usr/bin/mediainfo
       - RAILS_ENV=development
-      - SETTINGS__REDIS__HOST=redis
-      - SETTINGS__REDIS__PORT=6379
+      - REDIS_URL=redis://redis/90210
       - SECRET_KEY_BASE=abcd
       - SMTP_ADDRESS
       - SMTP_AUTHENTICATION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
 
   avalon:
     image: avalonmediasystem/avalon:6.x-dev
-    command: "/home/app/avalon/bin/docker-start"
+    command: "bin/docker-start"
     depends_on:
       - db
       - fcrepo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - POSTGRES_USER=postgres
     ports:
       - "5432:5432"
+
   fedora:
     image: avalonmediasystem/fedora:4.7.x
     depends_on:
@@ -28,16 +29,14 @@ services:
     ports:
       - "8984:8080"
   solr:
-    image: avalonmediasystem/solr:latest
+    image: solr:6.6
     ports:
       - "8983:8983"
     volumes:
       - solr:/opt/solr/server/solr/mycores
-    entrypoint:
-      - docker-entrypoint.sh
-      - solr-precreate
-      - avalon
-      - /opt/solr/avalon_conf
+      - ./solr/config:/config
+      - ./solr/scripts/solr-precreate-avalon.sh:/docker-entrypoint-initdb.d/solr-precreate-avalon.sh
+
   matterhorn:
     image: avalonmediasystem/matterhorn
     volumes:
@@ -98,7 +97,8 @@ services:
       - SMTP_PASSWORD
       - SMTP_PORT
       - SMTP_USER_NAME
-      - SOLR_URL=http://solr:8983/solr/avalon
+      - SOLR_URL=http://solr:8983/solr/development
+      - SOLR_TEST_URL=http://solr:8983/solr/test
       - SETTINGS__STREAMING__CONTENT_PATH=/streamfiles
       - SETTINGS__STREAMING__STREAM_DEFAULT_QUALITY=medium
       - SETTINGS__STREAMING__HTTP_BASE=http://localhost:8880/avalon

--- a/solr/scripts/solr-precreate-avalon.sh
+++ b/solr/scripts/solr-precreate-avalon.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# This is for docker! Customized script for our avalon (creates dev and test cores).
+#
+# This script was mostly stolen from the official solr-precreate script:
+# https://github.com/docker-solr/docker-solr/blob/master/scripts/solr-precreate
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+
+coredir_dev="$coresdir/development"
+if [[ ! -d $coredir_dev ]]; then
+    cp -r /config/ $coredir_dev
+    touch "$coredir_dev/core.properties"
+    echo "created development core"
+else
+    echo "core development already exists"
+fi
+
+coredir_test="$coresdir/test"
+if [[ ! -d $coredir_test ]]; then
+    cp -r /config/ $coredir_test
+    touch "$coredir_test/core.properties"
+    echo "created test core"
+else
+    echo "core test already exists"
+fi

--- a/spec/lib/avalon/batch/entry_spec.rb
+++ b/spec/lib/avalon/batch/entry_spec.rb
@@ -23,6 +23,15 @@ describe Avalon::Batch::Entry do
   let(:entry_opts) { {user_key: 'archivist1@example.org', collection: collection} }
   let(:entry) { Avalon::Batch::Entry.new(entry_fields, entry_files, entry_opts, nil, nil) }
 
+  before do
+    @old_queue_adaptor = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  after do
+    ActiveJob::Base.queue_adapter = @old_queue_adaptor
+  end
+
   describe '#file_valid?' do
     let(:filename) { 'spec/fixtures/dropbox/example_batch_ingest/assets/Vid1-1.mp4' }
     it 'should be valid if the file exists' do

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -302,24 +302,24 @@ describe MasterFile do
         }
 
         before(:each) do
-          @old_media_path = Settings.matterhorn.media_path
+          @old_media_path = Rails.application.secrets.matterhorn_client_media_path
           FileUtils.mkdir_p media_path
           FileUtils.cp fixture, tempfile
         end
 
         after(:each) do
-          Settings.matterhorn.media_path = @old_media_path
+          Rails.application.secrets.matterhorn_client_media_path = @old_media_path
           File.unlink subject.file_location
           FileUtils.rm_rf media_path
         end
 
         it "should rename an uploaded file in place" do
-          Settings.matterhorn.media_path = nil
+          Rails.application.secrets.matterhorn_client_media_path = nil
           expect(subject.file_location).to eq(File.realpath(File.join(File.dirname(tempfile),original)))
         end
 
         it "should copy an uploaded file to the media path" do
-          Settings.matterhorn.media_path = media_path
+          Rails.application.secrets.matterhorn_client_media_path = media_path
           expect(subject.file_location).to eq(File.join(media_path,original))
         end
       end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -772,6 +772,7 @@ describe MediaObject do
       expect(media_object.descMetadata.original_name).to eq 'descMetadata.xml'
     end
     it 'is a valid MODS document' do
+      optional "Requires an internet connection to fetch external schema definitions"
       media_object = FactoryGirl.create(:media_object, :with_master_file)
       xsd = Nokogiri::XML::Schema(File.read('spec/fixtures/mods-3-6.xsd'))
       expect(xsd.valid?(media_object.descMetadata.ng_xml)).to be_truthy

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,9 @@
 ENV['RAILS_ENV'] = 'test'
 ENV['SETTINGS__DOMAIN'] = 'http://test.host/'
 ENV['BASE_URL'] = 'http://test.host'
+if ENV['SOLR_URL'] && ENV['SOLR_TEST_URL']
+  ENV['SOLR_URL'] = ENV['SOLR_TEST_URL']
+end
 
 if ENV['COVERAGE'] || ENV['TRAVIS']
   require 'simplecov'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,12 +1,11 @@
-if ENV['RAILS_ENV'] != 'test'
-  ENV['RAILS_ENV'] = 'test'
-  if ENV['SOLR_URL']
-    if ENV['SOLR_TEST_URL']
-      ENV['SOLR_URL'] = ENV['SOLR_TEST_URL']
-    else
-      raise "You will likely wipe out your Solr instance!\n"\
-            "Please set SOLR_TEST_URL and try again."
-    end
+ENV['RAILS_ENV'] = 'test'
+# If `SOLR_URL` is set, we also want `SOLR_TEST_URL` to be set to prevent disaster.
+if ENV['SOLR_URL']
+  if ENV['SOLR_TEST_URL']
+    ENV['SOLR_URL'] = ENV['SOLR_TEST_URL']
+  else
+    raise "You will likely wipe out your Solr instance!\n"\
+          "Please set SOLR_TEST_URL and try again."
   end
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,17 @@
-ENV['RAILS_ENV'] = 'test'
-ENV['SETTINGS__DOMAIN'] = 'http://test.host/'
-ENV['BASE_URL'] = 'http://test.host'
+if ENV['RAILS_ENV'] != 'test'
+  ENV['RAILS_ENV'] = 'test'
+  unless ENV['SOLR_TEST_URL']
+    raise "You are going to wipe out your Solr instance!\n"\
+          "Please set SOLR_TEST_URL and try again."
+  end
+end
+
 if ENV['SOLR_URL'] && ENV['SOLR_TEST_URL']
   ENV['SOLR_URL'] = ENV['SOLR_TEST_URL']
 end
+
+ENV['SETTINGS__DOMAIN'] = 'http://test.host/'
+ENV['BASE_URL'] = 'http://test.host'
 
 if ENV['COVERAGE'] || ENV['TRAVIS']
   require 'simplecov'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,13 +1,13 @@
 if ENV['RAILS_ENV'] != 'test'
   ENV['RAILS_ENV'] = 'test'
-  unless ENV['SOLR_TEST_URL']
-    raise "You are going to wipe out your Solr instance!\n"\
-          "Please set SOLR_TEST_URL and try again."
+  if ENV['SOLR_URL']
+    if ENV['SOLR_TEST_URL']
+      ENV['SOLR_URL'] = ENV['SOLR_TEST_URL']
+    else
+      raise "You will likely wipe out your Solr instance!\n"\
+            "Please set SOLR_TEST_URL and try again."
+    end
   end
-end
-
-if ENV['SOLR_URL'] && ENV['SOLR_TEST_URL']
-  ENV['SOLR_URL'] = ENV['SOLR_TEST_URL']
 end
 
 ENV['SETTINGS__DOMAIN'] = 'http://test.host/'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,7 @@
+ENV['RAILS_ENV'] = 'test'
+ENV['SETTINGS__DOMAIN'] = 'http://test.host/'
+ENV['BASE_URL'] = 'http://test.host'
+
 if ENV['COVERAGE'] || ENV['TRAVIS']
   require 'simplecov'
   require 'codeclimate-test-reporter'
@@ -14,7 +18,6 @@ require 'aws-sdk'
 Aws.config[:stub_responses] = true
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
@@ -74,7 +77,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before :suite do
-    WebMock.disable_net_connect!(allow: ['localhost', '127.0.0.1', 'fedora', 'solr', 'matterhorn'])
+    WebMock.disable_net_connect!(allow: ['localhost', '127.0.0.1', 'fcrepo', 'solr', 'matterhorn'])
     DatabaseCleaner.clean_with(:truncation)
     ActiveFedora::Cleaner.clean!
     disable_production_minter!


### PR DESCRIPTION
Want a setup where the development and test environments don't clobber each other.
Prefer standard containers over homemade stuff (non-Avalon), where possible.

 - [x] Solr
 - [x] Fedora
 - [x] Database
 - [x] Redis
 - [x] Matterhorn
 - [x] Streaming/HLS/Nginx
 - [x] `development` and `test` environments working at the same time
 - [x] Able to run the webserver on the host machine

I've tried to make as many settings as possible originate from `secrets.yml`, with settings overridden by environment variables.

Currently, to have the avalon stack run in containers do:

`docker-compose up -d`

To have the avalon stack run in containers except the web server, do:

`docker-compose -f docker-compose.lightweight.yml up -d`

In both cases, the webserver will run in the browser at `http://localhost:3000`

