### PR TITLE
Flag required descriptive metadata form fields with red asterisk

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,3 +57,5 @@
 @import "branding";
 @import "nestable";
 @import "avalon";
+
+@import "era_custom";

--- a/app/assets/stylesheets/era_custom.scss
+++ b/app/assets/stylesheets/era_custom.scss
@@ -1,0 +1,7 @@
+span.tooltip-label-parenthesis {
+  font-weight: normal;
+  font-size: smaller;
+}
+span.tooltip-label-required {
+  color: red;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -160,7 +160,7 @@ module ApplicationHelper
   # @return [String] time in HH:MM:SS
   def pretty_time( milliseconds )
     duration = milliseconds/1000
-    Time.at(duration).utc.strftime(duration<3600?'%M:%S':'%H:%M:%S')
+    Time.at(duration).utc.strftime(duration < 3600 ? '%M:%S' : '%H:%M:%S')
   end
 
   def git_commit_info pattern="%s %s [%s]"
@@ -218,5 +218,15 @@ module ApplicationHelper
     @view_flow.set(:layout, output_buffer)
     output = render(:file => "layouts/#{layout}")
     self.output_buffer = ActionView::OutputBuffer.new(output)
+  end
+
+
+  def tooltip_label(options)
+    out = ''
+    out += content_tag(:span, '* ', class: 'tooltip-label-required') if options[:required]
+    out += h(options[:display_label])
+    out += content_tag(:span, " (#{h(options[:label_parenthesis])})",
+                       class: 'tooltip-label-parenthesis') if options[:label_parenthesis]
+    out.html_safe
   end
 end

--- a/app/views/media_objects/_mejs4_add_to_playlist.html.erb
+++ b/app/views/media_objects/_mejs4_add_to_playlist.html.erb
@@ -96,7 +96,7 @@ This view file goes with the custom 'Add To Playlist' MediaElement 4 plugin.
             <%= f.text_area :comment, class: 'form-control' %>
           </div>
           <div class="form-group playlist-visibility-form-group">
-            <%= label_tag nil, t("blacklight/folders/folder.visibility", scope: "helpers.label") %>
+            <%= label_tag nil, t("playlist.visibility") %>
             <label class="radio-inline">
               <%= f.radio_button(:visibility, Playlist::PUBLIC) %>
               <%= human_friendly_visibility Playlist::PUBLIC %>

--- a/app/views/media_objects/_resource_description.html.erb
+++ b/app/views/media_objects/_resource_description.html.erb
@@ -14,7 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <div id="resource_description_content">
-<p>Fields followed by an asterisk (*) are required.</p>
+<p><%= t(:required_field_html) %></p>
 <%= form_for @media_object, html: { class: 'form-vertical' } do |form| %>
   <%= hidden_field_tag :step, @active_step %>
 
@@ -29,31 +29,32 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   <%= render partial: 'text_field',
              locals: {form: form, field: :title,
-                      options: {required: true}} %>
-
-  <%= render partial: 'text_field',
-             locals: {form: form, field: :date_issued,
-                      options: {display_label: 'Publication date', required: true}} %>
+                      options: {label_parenthesis: t('metadata_parenthesis.title'),
+                                required: true}} %>
 
   <%= render partial: 'text_field',
              locals: {form: form, field: :creator,
-                      options: {display_label: 'Main contributor(s)', multivalued: true}} %>
+                      options: {display_label: t('metadata_label.creator'),
+                                label_parenthesis: t('metadata_parenthesis.creator'),
+                                required: true,
+                                multivalued: true}} %>
 
   <%= render partial: 'text_field',
-             locals: {form: form, field: :date_created,
-                      options: {display_label: 'Creation date'}} %>
+             locals: {form: form, field: :topical_subject,
+                      options: {display_label: t('metadata_label.topical_subject'),
+                                label_parenthesis: t('metadata_parenthesis.topical_subject'),
+                                required: true,
+                                multivalued: true}} %>
 
-  <%= render partial: 'text_area',
-             locals: {form: form, field: :abstract,
-                      options: {display_label: 'Summary'}} %>
-
+  <%# TODO: This needs to be hooked up to AJAX, separate PR %>
   <%= render partial: 'text_field',
-             locals: {form: form, field: :contributor,
-                      options: {multivalued: true}} %>
-
-  <%= render partial: 'text_field',
-             locals: {form: form, field: :publisher,
-                      options: {multivalued: true}} %>
+             locals: {form: form, field: :genre,
+                      options: {display_label: t('metadata_label.genre'),
+                                label_parenthesis: t('metadata_parenthesis.genre'),
+                                multivalued: true,
+                                # autocomplete_model: 'genreTerm',
+                                # autocomplete_validate: false,
+                                required: true}} %>
 
   <%= render partial: 'text_field',
              locals: {form: form, field: :language,
@@ -61,29 +62,55 @@ Unless required by applicable law or agreed to in writing, software distributed
                                 autocomplete_model: 'languageTerm',
                                 autocomplete_validate: false,
                                 autocomplete_display_key: :text,
+                                required: true,
                                 autocomplete_id_key: :code}} %>
 
   <%= render partial: 'text_field',
+             locals: { form: form, field: :date_issued,
+                       options: { display_label: t('metadata_label.date_issued'),
+                                  label_parenthesis: t('metadata_parenthesis.date_issued'),
+                                  required: true } } %>
+
+  <%= render partial: 'text_field',
+             locals: {form: form, field: :date_created,
+                     options: {display_label: t('metadata_label.date_created'),
+                               label_parenthesis: t('metadata_parenthesis.date_created')}} %>
+
+  <%= render partial: 'text_area',
+             locals: {form: form, field: :abstract,
+                      options: {display_label: 'Summary'}} %>
+
+  <%= render partial: 'text_field',
+             locals: {form: form, field: :contributor,
+                      options: {multivalued: true,
+                                display_label: t('metadata_label.contributor'),
+                                label_parenthesis: t('metadata_parenthesis.contributor')}} %>
+
+  <%= render partial: 'text_field',
+             locals: {form: form, field: :publisher,
+                      options: {multivalued: true,
+                                display_label: t('metadata_label.publisher'),
+                                label_parenthesis: t('metadata_parenthesis.publisher')}} %>
+
+  <%= render partial: 'text_field',
              locals: {form: form, field: :physical_description,
-                      options: {display_label: "Physical Description",
-                                multivalued: true}} %>
+                      options: {multivalued: true,
+                                display_label: t('metadata_label.physical_description'),
+                                label_parenthesis:
+                                  t('metadata_parenthesis.physical_description')}} %>
 
   <%= render partial: 'text_field',
              locals: {form: form, field: :related_item_url,
-                      options: {display_label: 'Related Item(s)',
+                      options: {display_label: t('metadata_label.related_item_url'),
+                                label_parenthesis:
+                                  t('metadata_parenthesis.related_item_url'),
                                 multivalued: true,
-                                primary_label: 'URL',
+                                primary_label: t('metadata_label.related_item_url_url'),
                                 primary_key: :url,
-                                secondary_label: 'Label',
+                                secondary_label: t('metadata_label.related_item_url_label'),
                                 secondary_key: :label,
                                 secondary_field: :related_item_label}} %>
 
-  <%= render partial: 'text_field',
-             locals: {form: form, field: :genre,
-                      options: {display_label: 'Genre(s)', multivalued: true}} %>
-  <%= render partial: 'text_field',
-             locals: {form: form, field: :topical_subject,
-                      options: {display_label: 'Subject(s)', multivalued: true}} %>
   <%= render partial: 'text_field',
              locals: {form: form, field: :temporal_subject,
                       options: {display_label: 'Time period(s)', multivalued: true}} %>
@@ -104,16 +131,17 @@ Unless required by applicable law or agreed to in writing, software distributed
                                 secondary_hash_key: :source,
                                 dropdown_field: :other_identifier_type,
                                 dropdown_options: ModsDocument::IDENTIFIER_TYPES}} %>
+
   <%= render partial: 'text_area',
              locals: {form: form, field: :table_of_contents,
                       options: {multivalued: true,
-                                display_label: 'Table of Contents'}} %>
+                                display_label: t('metadata_label.table_of_contents'),
+                                label_parenthesis:
+                                  t('metadata_parenthesis.table_of_contents') }} %>
   <%= render partial: 'text_area',
              locals: {form: form, field: :note,
                       options: {multivalued: true,
                                 display_label: 'Note(s)',
-                                primary_hash_key: :note,
-                                secondary_hash_key: :type,
                                 dropdown_field: :note_type,
                                 dropdown_options: ModsDocument::NOTE_TYPES }} %>
 

--- a/app/views/modules/_tooltip.html.erb
+++ b/app/views/modules/_tooltip.html.erb
@@ -17,7 +17,15 @@ Unless required by applicable law or agreed to in writing, software distributed
 
     <%= form.label(field, class: 'control-label') do %>
       <%= content_tag :span, class: 'tooltip-label', :'data-title' => options[:display_label], :'data-tooltip' => "##{field.to_s}_tooltip" do %>
-         <%= options[:display_label] %><% if options[:required] %>*<% end %>
+         <% if options[:required] %>
+           <span class="tooltip-label-required">* </span>
+         <% end %>
+         <%= options[:display_label] %>
+         <% if options[:label_parenthesis] %>
+           <span class="tooltip-label-parenthesis">
+              (<%= options[:label_parenthesis] %>)
+           </span>
+         <% end %>
          <%= content_tag :span, '', class: 'glyphicon glyphicon-question-sign' %>
       <% end %>
     <% end %>

--- a/app/views/modules/_tooltip.html.erb
+++ b/app/views/modules/_tooltip.html.erb
@@ -17,15 +17,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
     <%= form.label(field, class: 'control-label') do %>
       <%= content_tag :span, class: 'tooltip-label', :'data-title' => options[:display_label], :'data-tooltip' => "##{field.to_s}_tooltip" do %>
-         <% if options[:required] %>
-           <span class="tooltip-label-required">* </span>
-         <% end %>
-         <%= options[:display_label] %>
-         <% if options[:label_parenthesis] %>
-           <span class="tooltip-label-parenthesis">
-              (<%= options[:label_parenthesis] %>)
-           </span>
-         <% end %>
+         <%= tooltip_label(options) %>
          <%= content_tag :span, '', class: 'glyphicon glyphicon-question-sign' %>
       <% end %>
     <% end %>

--- a/app/views/playlists/_copy_playlist_modal.html.erb
+++ b/app/views/playlists/_copy_playlist_modal.html.erb
@@ -25,7 +25,7 @@
             <div class="col-sm-10"><%= f.text_area :comment, class: 'form-control', rows: '4' %></div>
           </div>
           <div class="row form-group">
-            <%= label_tag nil, t("blacklight/folders/folder.visibility", scope: "helpers.label"), class: 'col-sm-2 control-label' %>
+            <%= label_tag nil, t("playlist.visibility"), class: 'col-sm-2 control-label' %>
             <div class="col-sm-10">
               <label class="radio-inline">
                 <%= f.radio_button(:visibility, Playlist::PUBLIC) %>

--- a/app/views/playlists/_form.html.erb
+++ b/app/views/playlists/_form.html.erb
@@ -24,7 +24,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <div class="col-sm-10"><%= f.text_area :comment, class: 'form-control', rows: '4' %></div>
     </div>
     <div class="row form-group">
-      <%= label_tag nil, t("blacklight/folders/folder.visibility", scope: "helpers.label"), class: 'col-sm-2 control-label' %>
+      <%= label_tag nil, t("playlist.visibility"), class: 'col-sm-2 control-label' %>
       <div class="col-sm-10">
         <label class="radio-inline">
           <%= f.radio_button(:visibility, Playlist::PUBLIC) %>

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -38,7 +38,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <div class="col-sm-10"><%= @playlist.comment %></div>
     </div>
     <div class="row">
-      <div class="col-sm-2"><%= t("blacklight/folders/folder.visibility", scope: "helpers.label") %></div>
+      <div class="col-sm-2"><%= t("playlist.visibility") %></div>
       <div class="col-sm-10">
         <%= human_friendly_visibility @playlist.visibility %> - <i><%= visibility_description @playlist.visibility %></i>
         <% if @playlist.visibility == Playlist::PRIVATE_WITH_TOKEN %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,5 +42,5 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,5 +38,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,34 @@ en:
     empty_share_link: ""
     empty_share_link_notice: "After processing has started the embedded link will be available."
     empty_share_section_permalink_notice: "After processing has started the section link will be available."
+  metadata_label:
+    creator: 'Main contributor(s)'
+    additional_contributors: 'Additional contributor(s)'
+    topical_subject: 'Subject(s)'
+    date_issued: 'Publication date'
+    date_created: 'Creation date'
+    contributor: 'Additonal contributor(s)'
+    publisher: 'Publisher(s)'
+    physical_description: 'Physical Description'
+    related_item_url: 'Related Item(s)'
+    related_item_url_url: 'URL'
+    related_item_url_label: 'Item'
+    genre: 'Genre(s)'
+    table_of_contents: 'Table of Contents'
+  metadata_parenthesis:
+    title: 'Add a descriptive title or caption'
+    creator: 'Enter only one main contributor per box. Example: Doe, Jane B.'
+    topical_subject: 'Enter only one word or phrase per box'
+    date_issued:
+      'Enter in this format: YYYY-MM-DD, YYYY-MM or YYYY. Example: 2017-02-20'
+    date_created:
+      'Enter in this format: YYYY-MM-DD, YYYY-MM or YYYY. Example: 2017-02-20'
+    contributor: 'Enter only one additional contributor per box. Example: Jones, Mary'
+    publisher: 'Enter only one publisher per box. Example: University of Alberta Press'
+    physical_description: 'Example: 1 videocassette (20 minutes)'
+    related_item_url: 'Example: University of Alberta | http://www.ualberta.ca'
+    genre: 'Enter only one genre per box. Example: Interview'
+    table_of_contents: 'Example: Chapter 1 -- Chapter 2 -- Chapter 3'
   metadata_tip:
     abstract: |
       Summary provides a space for describing the contents of the item. Examples
@@ -213,3 +241,6 @@ en:
       playlist:
         title: "Name"
         comment: "Description"
+
+  required_field_html:
+    <strong><span class="tooltip-label-required">*</span> indicates required field</strong>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,6 +218,7 @@ en:
     publicAltText: "This playlist can be viewed by anyone on the web."
     private-with-tokenAltText: "This playlist can only be viewed by users who have the unique link."
 
+    visibility: "Visibility"
     privateText: "Private"
     publicText: "Public"
     private-with-tokenText: "Share by link"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,7 +113,7 @@ en:
       description of the content of a home movie). Lengthy titles may be truncated in
       the search results view.
     topical_subject: |
-      Subject should be used for the topical subject of the content. For
+      <strong>Required field.</strong>Subject should be used for the topical subject of the content. For
       consistency and to allow for sorting and aggregating, use terms from the
       <a href="http://id.loc.gov/authorities/subjects.html"
       target="_blank">Library of Congress Subject Headings</a>. For temporal
@@ -124,11 +124,10 @@ en:
     bibliographic_id: |
       Bibliographic ID should be used for an external record identifier that can connect the Avalon item to a catalog record or other record for the original item. Type specifies the type of external record identifier.
     language: |
-      Language describes the languages used in the item. Typing two or more
+      <strong>Required field.</strong>Language describes the languages used in the item. Typing two or more
       letters within the field will bring up permitted matches. Only terms or
       codes from the <a href="http://www.loc.gov/marc/languages/"
-      target="_blank">MARC Code List for Languages</a> may be used. This is an
-      optional field.
+      target="_blank">MARC Code List for Languages</a> may be used. Hint: for English language materials, type "English".
     terms_of_use: |
       Terms of Use describes the conditions under which content may be used. This is an optional field.
     physical_description: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,7 +113,7 @@ en:
       description of the content of a home movie). Lengthy titles may be truncated in
       the search results view.
     topical_subject: |
-      <strong>Required field.</strong>Subject should be used for the topical subject of the content. For
+      <strong>Required field.</strong> Subject should be used for the topical subject of the content. For
       consistency and to allow for sorting and aggregating, use terms from the
       <a href="http://id.loc.gov/authorities/subjects.html"
       target="_blank" rel="noopener nofollow">Library of Congress Subject Headings</a>. For temporal
@@ -124,7 +124,7 @@ en:
     bibliographic_id: |
       Bibliographic ID should be used for an external record identifier that can connect the Avalon item to a catalog record or other record for the original item. Type specifies the type of external record identifier.
     language: |
-      <strong>Required field.</strong>Language describes the languages used in the item. Typing two or more
+      <strong>Required field.</strong> Language describes the languages used in the item. Typing two or more
       letters within the field will bring up permitted matches. Only terms or
       codes from the <a href="http://www.loc.gov/marc/languages/"
       target="_blank" rel="noopener nofollow">MARC Code List for Languages</a> may be used. Hint: for English language materials, type "English".

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,44 +68,44 @@ en:
       a band or opera, conductor, arranger, cinematographer, and choreographer. At
       this time this is no ability to specify a contributor as a corporate body. When
       possible, use the <a href="http://id.loc.gov/authorities/names.html"
-      target="_blank">Library of Congress Name Authority File</a>.
+      target="_blank" rel="noopener nofollow">Library of Congress Name Authority File</a>.
     creator: |
       Main contributors are the primary persons
       or bodies associated with the creation of the content.  Main contributors
       will be included in search results display and aggregated for browsing
       access. At this time there is no ability to specify a main contributor as
       a corporate body. When possible, use the <a
-      href="http://id.loc.gov/authorities/names.html" target="_blank">Library of
+      href="http://id.loc.gov/authorities/names.html" target="_blank" rel="noopener nofollow">Library of
       Congress Name Authority File</a>.
     date_created: |
       Creation date should only be used if Date is a re-issue date. Then Creation date
       would contain the original publication date. Enter date information in a format
       consistent with the options shown in <a
       href="http://www.loc.gov/standards/datetime/pre-submission.html"
-      target="_blank">Extended Date/Time Format (EDTF) 1.0</a>.
+      target="_blank" rel="noopener nofollow">Extended Date/Time Format (EDTF) 1.0</a>.
     date_issued: |
       <strong>Required field.</strong> Date should be the main publication date
       associated with the item to be used for sorting browse and search results.
       Enter date information in a format consistent with the options shown in <a
       href="http://www.loc.gov/standards/datetime/pre-submission.html"
-      target="_blank">Extended Date/Time Format (EDTF) 1.0</a>.
+      target="_blank" rel="noopener nofollow">Extended Date/Time Format (EDTF) 1.0</a>.
     genre: |
       Genre can be used to categorize an item by form, style, or subject matter. For
       consistency and to allow for sorting and aggregating, use terms from the <a
       href="http://metadataregistry.org/concept/list/vocabulary_id/148.html"
-      target="_blank">Open Metadata Registry labels for PBCore: pbcoreGenre</a>.
+      target="_blank" rel="noopener nofollow">Open Metadata Registry labels for PBCore: pbcoreGenre</a>.
     geographic_subject: |
       Location should be used for the geographic subject of the content. For
       consistency and to allow for sorting and aggregating, use terms from the
       <a href="http://www.getty.edu/research/tools/vocabularies/tgn/index.html"
-      target="_blank">Getty Thesaurus of Geographic Names</a>.
+      target="_blank" rel="noopener nofollow">Getty Thesaurus of Geographic Names</a>.
     publisher: |
       Publisher of the content of the item.
     temporal_subject: |
       Time period should be used for the temporal subject of the content (for example,
       years or year ranges). Enter date information in a format consistent with the
       options shown in <a href="http://www.loc.gov/standards/datetime/pre-
-      submission.html" target="_blank">Extended Date/Time Format (EDTF) 1.0</a>.
+      submission.html" target="_blank" rel="noopener nofollow">Extended Date/Time Format (EDTF) 1.0</a>.
     title: |
       <strong>Required field.</strong> Title is used for display in search results and
       single item views. Recommended use is to reflect the content captured in
@@ -116,7 +116,7 @@ en:
       <strong>Required field.</strong>Subject should be used for the topical subject of the content. For
       consistency and to allow for sorting and aggregating, use terms from the
       <a href="http://id.loc.gov/authorities/subjects.html"
-      target="_blank">Library of Congress Subject Headings</a>. For temporal
+      target="_blank" rel="noopener nofollow">Library of Congress Subject Headings</a>. For temporal
       subjects, use the Time period(s) field and for geographic subjects, use
       the Location(s) field in this form. See below.
     permalink: |
@@ -127,7 +127,7 @@ en:
       <strong>Required field.</strong>Language describes the languages used in the item. Typing two or more
       letters within the field will bring up permitted matches. Only terms or
       codes from the <a href="http://www.loc.gov/marc/languages/"
-      target="_blank">MARC Code List for Languages</a> may be used. Hint: for English language materials, type "English".
+      target="_blank" rel="noopener nofollow">MARC Code List for Languages</a> may be used. Hint: for English language materials, type "English".
     terms_of_use: |
       Terms of Use describes the conditions under which content may be used. This is an optional field.
     physical_description: |
@@ -208,7 +208,7 @@ en:
     show:
       title: '%{media_object_title} - %{application_name}'
     player:
-      customError: 'Your browser requires Adobe Flash Player in order to play this item. For more information, see <a href="https://helpx.adobe.com/flash-player.html" target="_blank">Adobe Flash Player Help</a>.'
+      customError: 'Your browser requires Adobe Flash Player in order to play this item. For more information, see <a href="https://helpx.adobe.com/flash-player.html" target="_blank" rel="noopener nofollow">Adobe Flash Player Help</a>.'
 
   playlist:
     ago: "%{time} ago"


### PR DESCRIPTION
Also:
* Add an optional parenthetical remark for form labels
* required fields first, matching the order of Avalon 5 website.
* raise error on missing translations in dev/test.
* Make everything touched in the view go through i18n

Screenshot looks similar to: https://github.com/ualbertalib/avalon/issues/7#issuecomment-296298349

Fixes #295
See also original Avalon 5 work: #132 #7 #94 1c9b2dbb6911dcb2697cc594019b1bb9a7e892b9 bf151f77298ab3711c6b0264ac580842f608b1a2
