### PR TITLE
Controlled vocabulary changes:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ vendor/bundle
 ## PROJECT::SPECIFIC
 config/authentication.yml
 config/avalon.yml
-config/controlled_vocabulary.yml
 config/role_map_development.yml
 config/initializers/rubyhorn.rb
 #config/lti.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install mediainfo
   - sudo ln -s /usr/bin/lsof /usr/sbin/lsof
-  - cp config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
   - bundle config without development:production
 before_script:
   - bundle exec rake db:create

--- a/bin/docker-start
+++ b/bin/docker-start
@@ -16,8 +16,6 @@ export HOME=/home/app
 bundle config build.nokogiri --use-system-libraries && \
 bundle install --path=/home/app/gems --with postgres aws test
 
-cp config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
-
 bundle exec rake db:create
 
 if [[ "$RAILS_ENV" =~ ^(production|uat|staging)$ ]]; then

--- a/config/controlled_vocabulary.yml
+++ b/config/controlled_vocabulary.yml
@@ -1,0 +1,22 @@
+units:
+  - Default Unit
+identifier_types:
+  local: Catalog Key
+  oclc: OCLC
+  lccn: LCCN
+  issue number: Issue Number
+  matrix number: Matrix Number
+  music publisher: Music Publisher/Label
+  videorecording identifier: Videorecording Identifier
+  archival identifier: Archival Identifier
+  other: Other
+note_types:
+  general: General Note
+  awards: Awards
+  biographical/historical: Bibliographical/Historical Note
+  creation/production credits: Creation/Production Credits
+  language: Language Note
+  local: Local Note
+  performers: Performers
+  statement of responsibility: Statement of Responsibility
+  venue: Venue/Event Date


### PR DESCRIPTION
  * Track config/controlled_vocabulary.yml with git
  * Re-indent (two spaces in yaml rather than one)
  * Add 'Archival Identifier' to identifier types.
  * Don't allow docker/travis to clobber controlled vocabulary

Fixes #314 