### PR TITLE
Re-adding Google Analytics.

### DIFF
--- a/app/views/application/_analytics.html.erb
+++ b/app/views/application/_analytics.html.erb
@@ -1,0 +1,12 @@
+<% if Rails.application.secrets.google_analytics_token.present? %>
+  <!-- Google Analytics -->
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  
+    ga('create', '<%= Rails.application.secrets.google_analytics_token %>', 'auto');
+    ga('send', 'pageview');
+  </script>
+<% end %>

--- a/app/views/layouts/avalon.html.erb
+++ b/app/views/layouts/avalon.html.erb
@@ -43,6 +43,7 @@ Unless required by applicable law or agreed to in writing, software distributed
          if they are included here. That means the important content will
          load first; the page will not gag on trying to pull down files
          from a CDN -->
+    <%= render partial: 'analytics' %>
     <%= javascript_include_tag "application" %>
     <%= yield :page_scripts %>
   </body>

--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -34,6 +34,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   <body>
     <%= yield %>
+    <%= render partial: 'analytics' %>
     <%= javascript_include_tag "application" %>
     <%= yield :page_scripts %>
   </body>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -77,3 +77,4 @@ production:
   fcrepo_url: <%= ENV['FCREPO_URL'] %>
   fcrepo_base_path: /prod
   solr_url: <%= ENV['SOLR_URL'] %>
+  google_analytics_token: <%= ENV['GOOGLE_ANALYTICS_TOKEN'] %>


### PR DESCRIPTION
Mixing the approaches used by avalon and Jupiter. Note: Unlike Jupiter, Avalon doesn't use turbolinks.

Avalon: https://github.com/ualbertalib/avalon/commit/17c07db4d7994ede3392ff7820e8e4955879f942?w=1
Jupiter: https://github.com/ualbertalib/jupiter/commit/f566d04c10f5fddfbd80af3a52af6bff33819f90

Fixes #318 
