### PR TITLE
Point Gemfile to a version of rubyhorn that has a five minute timeout by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@
   gem 'haml'
 
   gem 'active_encode', git: "https://github.com/projecthydra-labs/active_encode.git", tag: 'v0.0.3'
-  gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git"
+  gem 'rubyhorn', git: "https://github.com/ualbertalib/rubyhorn.git", branch: 'increase-timeout-test'
   gem 'validates_email_format_of'
   gem 'loofah', '~> 2.2.1'
   gem 'rails-html-sanitizer', '~> 1.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,19 +166,6 @@ GIT
       mediashelf-loggable
 
 GIT
-  remote: https://github.com/avalonmediasystem/rubyhorn.git
-  revision: 9849835a4711f671371e8ef8b18e87bb9183cbba
-  specs:
-    rubyhorn (0.0.6)
-      activesupport
-      json
-      mediashelf-loggable
-      mime-types
-      net-http-digest_auth
-      om
-      rest-client
-
-GIT
   remote: https://github.com/bricestacey/ruby-zoom.git
   revision: 5348fd415520fa08af33ca7b84113a93d2da9f10
   specs:
@@ -200,6 +187,20 @@ GIT
     modal_logic (0.0.7)
       handlebars_assets (= 0.14.1)
       rails (>= 4)
+
+GIT
+  remote: https://github.com/ualbertalib/rubyhorn.git
+  revision: fb80213ddbf6294abd1049db201a321e0c846816
+  branch: increase-timeout-test
+  specs:
+    rubyhorn (0.0.6)
+      activesupport
+      json
+      mediashelf-loggable
+      mime-types
+      net-http-digest_auth
+      om
+      rest-client
 
 GEM
   remote: http://rubygems.org/
@@ -545,7 +546,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mysql2 (0.3.21)
-    net-http-digest_auth (1.4)
+    net-http-digest_auth (1.4.1)
     net-http-persistent (2.9.4)
     net-ldap (0.16.1)
     net-scp (1.2.1)


### PR DESCRIPTION
Seems to fix issues with timeouts on encoding large files.