### PR TITLE
Fix path that matterhorn encoder sees

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -276,8 +276,8 @@ class MasterFile < ActiveFedora::Base
   def matterhorn_path
     # This returns the URI path on the matterhorn server of the file who's path is on
     # the app server (so the path doesn't need to be the same on both servers)
-    new_path = file_location.gsub(Rails.application.secrets.matterhorn_client_media_path,
-                                  Rails.application.secrets.matterhorn_server_media_path)
+    new_path = working_file_path.gsub(Rails.application.secrets.matterhorn_client_media_path,
+                                      Rails.application.secrets.matterhorn_server_media_path)
 
     FileLocator.new(new_path).uri.to_s
   end

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -276,8 +276,11 @@ class MasterFile < ActiveFedora::Base
   def matterhorn_path
     # This returns the URI path on the matterhorn server of the file who's path is on
     # the app server (so the path doesn't need to be the same on both servers)
-    new_path = working_file_path.gsub(Rails.application.secrets.matterhorn_client_media_path,
-                                      Rails.application.secrets.matterhorn_server_media_path)
+
+    # Prefer working_file_path, when available
+    old_path = working_file_path || file_location
+    new_path = old_path.gsub(Rails.application.secrets.matterhorn_client_media_path,
+                             Rails.application.secrets.matterhorn_server_media_path)
 
     FileLocator.new(new_path).uri.to_s
   end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -147,7 +147,7 @@ describe MasterFile do
     end
     it 'starts an ActiveEncode workflow' do
       master_file.process
-      expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, "file://" + URI.escape(master_file.file_location), {preset: master_file.workflow_name})
+      expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, URI.escape(master_file.matterhorn_path), {preset: master_file.workflow_name})
       # expect(encode_job).to have_received(:perform)
     end
     describe 'already processing' do


### PR DESCRIPTION
Since upgrade to Avalon 6.4.3, matterhorn isn't seeing files in the right place.
Hopefully this fixes it, and helps encoding to work on UAT.
