### PR TITLE
Batch ingest was interpreting the terms of use field as an array

### DIFF
--- a/app/models/concerns/media_object_mods.rb
+++ b/app/models/concerns/media_object_mods.rb
@@ -313,7 +313,7 @@ module MediaObjectMods
   end
   def terms_of_use=(value)
     delete_all_values(:terms_of_use)
-    descMetadata.add_terms_of_use(value) if value.present?
+    descMetadata.add_terms_of_use(Array(value).first) if value.present?
   end
 
   # has_attributes :table_of_contents, datastream: :descMetadata, at: [:table_of_contents], multiple: true


### PR DESCRIPTION
(then converting it to a string, e.g. a spreadsheet entry with "My license"
was being converted to `"\[\"My license\"\]"`).
This change handles the terms of use field the same way as the title field
is treated.
