### PR TITLE
switch backend from PostgreSQL to mysql (MariaDB)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ git:
   submodules: false
 bundler_args: --with mysql aws --without development debug
 env:
-  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_TEST_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test DATABASE_URL=mysql2://root:mysecretpassword@127.0.0.1:3306/
+  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_TEST_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test DATABASE_URL=mysql2://root:@127.0.0.1:3306/
 services:
   - mysql2
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 ---
 git:
   submodules: false
-bundler_args: --with postgres aws --without development debug
+bundler_args: --with mysql aws --without development debug
 env:
-  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_TEST_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test DATABASE_URL=postgresql://postgres:@127.0.0.1:5432/
+  - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_TEST_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test DATABASE_URL=mysql2://root:mysecretpassword@127.0.0.1:3306/
 services:
   - mysql2
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ bundler_args: --with mysql aws --without development debug
 env:
   - FCREPO_URL=http://127.0.0.1:8986/rest SOLR_TEST_URL=http://127.0.0.1:8985/solr/hydra-test RAILS_ENV=test DATABASE_URL=mysql2://root:@127.0.0.1:3306/
 services:
-  - mysql2
   - redis-server
+addons:
+  - mariadb: '10.3'
 before_install:
   - sudo rm -vf /etc/apt/sources.list.d/*riak*
   - sudo rm -vf /etc/apt/sources.list.d/*hhvm*

--- a/bin/docker-start
+++ b/bin/docker-start
@@ -14,7 +14,7 @@ cd /home/app/avalon
 
 export HOME=/home/app
 bundle config build.nokogiri --use-system-libraries && \
-bundle install --path=/home/app/gems --with postgres aws test
+bundle install --path=/home/app/gems --with mysql aws test
 
 bundle exec rake db:create
 

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,3 +1,3 @@
 test:
-  adapter: postgresql
+  adapter: mysql2 
   database: travis_ci_test

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@
 # `sudo -u postgres createuser ${USER}`
 # `sudo -u postgres alter user ${USER} superuser
 default: &default
-  adapter: postgresql
+  adapter: mysql
   encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 

--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -16,15 +16,15 @@ volumes:
 
 services:
   db:
-    image: postgres:9.6-alpine
+    image: mariadb:10.3
     environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
-      POSTGRES_PASSWORD: mysecretpassword
-      POSTGRES_USER: avalon
+      MYSQL_ROOT_PASSWORD: mysecretpassword
+      MYSQL_PASSWORD: mysecretpassword
+      MYSQL_USER: avalon
     volumes:
-      - database:/var/lib/postgresql/data
+      - database:/var/lib/mysql
     ports:
-      - "5432:5432"
+      - "3306:3306"
 
   fcrepo:
     image: ualbertalib/docker-fcrepo4
@@ -50,6 +50,7 @@ services:
       - work:/work
     ports:
       - "8080:8080"
+
   hls:
     image: avalonmediasystem/nginx
     network_mode: "host"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,15 +18,15 @@ volumes:
 
 services:
   db:
-    image: postgres:9.6-alpine
+    image: mariadb:10.3
     environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
-      POSTGRES_PASSWORD: mysecretpassword
-      POSTGRES_USER: avalon
+      MYSQL_ROOT_PASSWORD: mysecretpassword
+      MYSQL_PASSWORD: mysecretpassword
+      MYSQL_USER: avalon
     volumes:
-      - database:/var/lib/postgresql/data
+      - database:/var/lib/mysql
     ports:
-      - "5432:5432"
+      - "3306:3306"
 
   fcrepo:
     image: ualbertalib/docker-fcrepo4
@@ -52,6 +52,7 @@ services:
       - work:/work
     ports:
       - "8080:8080"
+
   hls:
     image: avalonmediasystem/nginx
     network_mode: "host"
@@ -85,7 +86,7 @@ services:
       - AVALON_DB_PASSWORD=avalondb
       - SETTINGS__DOMAIN=http://localhost:3000
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
-      - DATABASE_URL=postgresql://avalon:mysecretpassword@db:5432/
+      - DATABASE_URL=mysql2://root:mysecretpassword@db:3306/
       - SETTINGS__DROPBOX__PATH=/masterfiles
       - SETTINGS__DROPBOX__UPLOAD_URI=./masterfiles
       - EMAIL_COMMENTS

--- a/test.yml
+++ b/test.yml
@@ -15,10 +15,9 @@ services:
     environment:
       - AVALON_DB_PASSWORD=avalondb
       - FEDORA_DB_PASSWORD=fedoradb
-      - PGDATA=/data
-      - POSTGRES_USER=postgres
+      - MYSQL_ROOT_PASSWORD: mysecretpassword
     ports:
-      - "5432:5432"
+      - "3306:3306"
   fedora:
     image: avalonmediasystem/fedora:4.x
     environment:
@@ -67,7 +66,7 @@ services:
       - AVALON_DB_PASSWORD=avalondb
       - BASE_URL=http://test.host
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
-      - DATABASE_URL=postgres://avalon:${AVALON_DB_PASSWORD}@db/avalon
+      - DATABASE_URL=mysql2://avalon:${AVALON_DB_PASSWORD}@db/avalon
       - SETTINGS__DROPBOX__PATH=/masterfiles/dropbox
       - SETTINGS__DROPBOX__UPLOAD_URI=./masterfiles/dropbox
       - EMAIL_COMMENTS


### PR DESCRIPTION
Fixes #404 

Ease migration path from Avalon 5 to 6 by retaining a MySQL backend. The current Avalon 5 instance utilizes MySQL while the Avalon 6 Docker and Travis test set use PostgreSQL. To avoid the risks and unknowns associated with migrating the existing data from MySQL to PostgreSQL, move the Avalon 6 Docker and tests from PostgreSQL to MySQL (MariaDB).

* Updates docker to use MySQL (MariaDB)
* Updates Travis tests
