### PR TITLE
WIP: Return config handling to match upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ### Changed
 
+- Alter config parameter handling to match upstream PR [#413](https://github.com/ualbertalib/avalon/pull/413)
+  - Note: matterhorn client and server media_path 
 - switch backend from PostgreSQL to MySQL (MariaDB) - Docker & Travis [#405](https://github.com/ualbertalib/avalon/pull/405)
 - resource description form: remove ability to import by bibliographic id [#398](https://github.com/ualbertalib/avalon/pull/398)
 - resource description form: add deposit agreement checkbox [#394](https://github.com/ualbertalib/avalon/pull/394)

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -282,8 +282,8 @@ class MasterFile < ActiveFedora::Base
     unless old_path.present? && File.exists?(old_path)
       old_path = file_location
     end
-    new_path = old_path.gsub(Rails.application.secrets.matterhorn_client_media_path,
-                             Rails.application.secrets.matterhorn_server_media_path)
+    new_path = old_path.gsub(Settings.matterhorn.client_media_path,
+                             Settings.matterhorn.server_media_path)
 
     FileLocator.new(new_path).uri.to_s
   end
@@ -529,7 +529,7 @@ class MasterFile < ActiveFedora::Base
 
   def working_file_path
     path = nil
-    config_path = Rails.application.secrets.matterhorn_client_media_path
+    config_path = Settings.matterhorn.client_media_path
     path = File.join(config_path, File.basename(self.file_location)) if config_path.present? && File.directory?(config_path)
     path
   end
@@ -731,7 +731,7 @@ class MasterFile < ActiveFedora::Base
     else
       # Do nothing
     end
-    CleanupWorkingFileJob.perform_later(self.id) unless Rails.application.secrets.matterhorn_client_media_path.blank?
+    CleanupWorkingFileJob.perform_later(self.id) unless Settings.matterhorn.client_media_path.blank?
   end
 
   def update_ingest_batch

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter: solr
-  url: <%= Rails.application.secrets.solr_url %>
+  url: <%= ENV['SOLR_URL'] || 'http://localhost:8983/solr/development' %>
 development:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || 'http://localhost:8983/solr/development' %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -53,8 +53,8 @@ test:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
 uat:
-  url: <%= Rails.application.secrets.database_url %>
+  url: <%= ENV['DATABASE_URL'] %>
 staging:
-  url: <%= Rails.application.secrets.database_url %>
+  url: <%= ENV['DATABASE_URL'] %>
 production:
-  url: <%= Rails.application.secrets.database_url %>
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,8 +1,8 @@
 default: &default
-  user: <%= Rails.application.secrets.fcrepo_user %>
-  password: <%= Rails.application.secrets.fcrepo_password %>
-  url: <%= Rails.application.secrets.fcrepo_url %>
-  base_path: <%= Rails.application.secrets.fcrepo_base_path %>
+  user: fedoraAdmin
+  password: fedoraAdmin
+  url: <%= ENV['FCREPO_URL'] || 'http://localhost:8984/fcrepo/rest' %>
+  base_path: /dev
 development:
   <<: *default
 test:

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -3,7 +3,7 @@ if ["development", "test"].include?(Rails.env)
   config.cache_store = :memory_store, { size: 64.megabytes }
 else
   config.cache_store = :redis_store, {
-    url: Rails.application.secrets.redis_url,
+    url: Settings.redis_url,
     namespace: 'avalon'
   }
 end

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -3,7 +3,7 @@ if ["development", "test"].include?(Rails.env)
   config.cache_store = :memory_store, { size: 64.megabytes }
 else
   config.cache_store = :redis_store, {
-    url: Settings.redis_url,
+    url: Settings.redis.url,
     namespace: 'avalon'
   }
 end

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,7 +1,7 @@
 rails_root = ENV['RAILS_ROOT'] || File.dirname(__FILE__) + '/../..'
 rails_env = ENV['RAILS_ENV'] || 'development'
 
-Resque.redis = ENV['REDIS_URL'] || "#{Settings.redis.host}:#{Settings.redis.p  ort}"
+Resque.redis = ENV['REDIS_URL'] || "#{Settings.redis.host}:#{Settings.redis.port}"
 
 Resque.logger = Logger.new(Rails.root.join('log', "#{Rails.env}_resque.log"))
 Resque.logger.level = Logger::INFO

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,7 +1,7 @@
 rails_root = ENV['RAILS_ROOT'] || File.dirname(__FILE__) + '/../..'
 rails_env = ENV['RAILS_ENV'] || 'development'
 
-Resque.redis = Rails.application.secrets.redis_url
+Resque.redis = ENV['REDIS_URL'] || "#{Settings.redis.host}:#{Settings.redis.p  ort}"
 
 Resque.logger = Logger.new(Rails.root.join('log', "#{Rails.env}_resque.log"))
 Resque.logger.level = Logger::INFO

--- a/config/lti.yml
+++ b/config/lti.yml
@@ -1,8 +1,8 @@
 ---
-<%# Rails.application.secrets.lti_servers holds a list of server names
+<%# LTI_SERVERS holds a list of server names
     For each server, we need to map LTI request variables to something Avalon/OmniAuth can use.
     Here, `context_id` is the course name, which corresponds to an access group in Avalon. %>
-<% Array(Rails.application.secrets.lti_servers).each do |server| %>
+<% Array(ENV['LTI_SERVERS']).each do |server| %>
 <%= server %>:
   :uid: :lis_person_contact_email_primary
   :email: :lis_person_contact_email_primary

--- a/config/matterhorn.yml
+++ b/config/matterhorn.yml
@@ -1,5 +1,6 @@
 development: &default
-  url: <%= Rails.application.secrets.matterhorn_url %>
+  url: <%= ENV['MATTERHORN_URL'] ||
+           "http://matterhorn_system_account:CHANGE_ME@localhost:8080/" %> 
 test:
   <<: *default
 uat:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,54 +13,15 @@
 # TODO: rails 4.2 doesn't support 'shared', but rails 5.1 does
 #   ... so need to update this is we upgrade.
 shared: &shared
-  redis_url: <%= ENV['REDIS_URL'] %>
-  matterhorn_url: <%= ENV['MATTERHORN_URL'] %>
-  matterhorn_client_media_path: <%= ENV['MATTERHORN_CLIENT_MEDIA_PATH'] %>
-  matterhorn_server_media_path: <%= ENV['MATTERHORN_SERVER_MEDIA_PATH'] %>
-  lti_servers:
-<% ENV['LTI_SERVERS'].to_s.split.each do |server| %>
-    - <%= server %>
-<% end %>
-  lti_auth_key: <%= ENV['LTI_AUTH_KEY'] %>
-  lti_auth_secret: <%= ENV['LTI_AUTH_SECRET'] %>
-  email_comments: <%= ENV['EMAIL_COMMENTS'] || 'avalon-comments@example.edu' %>
-  email_notification: <%= ENV['EMAIL_NOTIFICATION'] ||
-                          'avalon-notifications@example.edu'%>
-  email_support: <%= ENV['EMAIL_SUPPORT'] || 'avalon-support@example.edu'%>
-  email_errors: <%= ENV['EMAIL_ERRORS'] || 'avalon-errors@example.edu' %>
+  rollbar_token: ''
 
 development:
   <<: *shared
   secret_key_base: 8268df0c1b5843bec6d0e6e1095b187766ff6a8f9c1edd4360588d357253fac09c95aebc715f25cb3ecfdf45cfb2da6c1c033149e93a363f3808da67b0b8ab09
-  fcrepo_url: <%= ENV['FCREPO_URL'] || 'http://localhost:8984/fcrepo/rest' %>
-  fcrepo_user: fedoraAdmin
-  fcrepo_password: fedoraAdmin
-  fcrepo_base_path: /dev
-  redis_url: <%= ENV['REDIS_URL'] || 'redis://localhost:6379' %>
-  matterhorn_url: <%= ENV['MATTERHORN_URL'] ||
-                      "http://matterhorn_system_account:CHANGE_ME@localhost:8080/" %>
-  matterhorn_client_media_path: <%= ENV['MATTERHORN_CLIENT_MEDIA_PATH'] ||
-                                    File.join(Rails.root, 'masterfiles') %>
-  matterhorn_server_media_path: <%= ENV['MATTERHORN_SERVER_MEDIA_PATH'] ||
-                                    '/masterfiles' %>
-  rollbar_token: ''
 
 test:
   <<: *shared
   secret_key_base: f589c05f948f5760c95e5c60fa0fb325a9fa7e8c9ba8190d22b8ff868927215dd4e5252227245dd26b4e98c9441ce5ef34a14ea25b2170191cb3f5ddad6c5755
-  fcrepo_url: <%= ENV['FCREPO_URL'] || 'http://localhost:8984/fcrepo/rest' %>
-  fcrepo_user: fedoraAdmin
-  fcrepo_password: fedoraAdmin
-  fcrepo_base_path: /test
-  redis_url: <%= ENV['REDIS_URL'] || 'redis://localhost:6379' %>
-
-  matterhorn_url: <%= ENV['MATTERHORN_URL'] ||
-                      "http://matterhorn_system_account:CHANGE_ME@localhost:8080/" %>
-  matterhorn_client_media_path: <%= ENV['MATTERHORN_CLIENT_MEDIA_PATH'] ||
-                                    File.join(Rails.root, 'masterfiles') %>
-  matterhorn_server_media_path: <%= ENV['MATTERHORN_SERVER_MEDIA_PATH'] ||
-                                    '/masterfiles' %>
-  rollbar_token: ''
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
@@ -69,35 +30,12 @@ uat:
   <<: *shared
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
-  database_url: <%= ENV['DATABASE_URL'] %>
-  fcrepo_user: <%= ENV['FCREPO_USER'] %>
-  fcrepo_password: <%= ENV['FCREPO_PASSWORD'] %>
-  fcrepo_url: <%= ENV['FCREPO_URL'] %>
-  fcrepo_base_path: /uat
-  solr_url: <%= ENV['SOLR_URL'] %>
-  rollbar_token: ''
-
 staging:
   <<: *shared
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
-  database_url: <%= ENV['DATABASE_URL'] %>
-  fcrepo_user: <%= ENV['FCREPO_USER'] %>
-  fcrepo_password: <%= ENV['FCREPO_PASSWORD'] %>
-  fcrepo_url: <%= ENV['FCREPO_URL'] %>
-  fcrepo_base_path: /staging
-  solr_url: <%= ENV['SOLR_URL'] %>
-  rollbar_token: ''
-
 production:
   <<: *shared
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-
-  database_url: <%= ENV['DATABASE_URL'] %>
-  fcrepo_user: <%= ENV['FCREPO_USER'] %>
-  fcrepo_password: <%= ENV['FCREPO_PASSWORD'] %>
-  fcrepo_url: <%= ENV['FCREPO_URL'] %>
-  fcrepo_base_path: /prod
-  solr_url: <%= ENV['SOLR_URL'] %>
   rollbar_token: <%= ENV['ROLLBAR_TOKEN'] %>
   google_analytics_token: <%= ENV['GOOGLE_ANALYTICS_TOKEN'] %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,16 +12,18 @@ matterhorn:
   root: 'http://localhost:8080/'
   baseApplication: 'avalon'
   cleanup_log: 'log/cleanup_jobs.log'
+  client_media_path: '/masterfiles'
+  server_media_path: '/masterfiles'
 mediainfo:
   path: '/usr/bin/mediainfo'
 ffmpeg:
   path: '/usr/local/bin/ffmpeg'
 email:
   mailer: :smtp
-  comments: <%= Rails.application.secrets.email_comments %>
-  notification: <%= Rails.application.secrets.email_notification %>
-  support: <%= Rails.application.secrets.email_support %>
-  errors: <%= Rails.application.secrets.email_errors %>
+  comments: 'avalon-comments@example.edu'
+  notification: 'avalon-notifications@example.edu'
+  support: 'avalon-support@example.edu'
+  errors: 'avalon-errors@example.edu'
 solr:
   configset: avalon
   configset_source_path: <%= File.join(Rails.root, 'solr', 'config') %>
@@ -75,11 +77,11 @@ auth:
       :params:
         :fields:
         - :email
-<% if Rails.application.secrets.lti_auth_key.present? %>
+<% if ENV['LTI_AUTH_KEY'] %>
     - :name: Avalon LTI OAuth
       :provider: :lti
       :hidden: true
       :params:
         :oauth_credentials:
-          <%= Rails.application.secrets.lti_auth_key %>: <%= Rails.application.secrets.lti_auth_secret %>
+          <%= ENV['LTI_AUTH_KEY'] %>: <%= ENV['LTI_AUTH_SECRET'] %> 
 <% end %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,19 @@
 domain:
   port: 3000
+
+matterhorn:
+  url: <%= ENV['MATTERHORN_URL'] ||
+           "http://matterhorn_system_account:CHANGE_ME@localhost:8080/" %> 
+  client_media_path: <%= ENV['MATTERHORN_CLIENT_MEDIA_PATH'] ||
+                                    File.join(Rails.root, 'masterfiles') %>
+  server_media_path: <%= ENV['MATTERHORN_SERVER_MEDIA_PATH'] ||
+                                    '/masterfiles' %>
+
+solr:
+  url: <%= ENV['SOLR_URL'] || 'http://localhost:8983/solr/development' %>
+
+blacklight:
+  url: <%= ENV['SOLR_URL'] || 'http://localhost:8983/solr/development' %>
+
+redis:
+  url: <%= ENV['REDIS_URL'] || 'http://localhost:6379' %>

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,6 +1,6 @@
 # Needed and used by active fedora, to specify where to find solr
 default: &default
-  url: <%= Rails.application.secrets.solr_url %>
+  url: <%= ENV['SOLR_URL'] || 'http://localhost:8983/solr/development' %>
 development:
   url: <%= ENV['SOLR_URL'] || 'http://localhost:8983/solr/development' %>
 test:

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -328,24 +328,24 @@ describe MasterFile do
         }
 
         before(:each) do
-          @old_media_path = Rails.application.secrets.matterhorn_client_media_path
+          @old_media_path = Settings.matterhorn.client_media_path
           FileUtils.mkdir_p media_path
           FileUtils.cp fixture, tempfile
         end
 
         after(:each) do
-          Rails.application.secrets.matterhorn_client_media_path = @old_media_path
+          Settings.matterhorn.client_media_path = @old_media_path
           File.unlink subject.file_location
           FileUtils.rm_rf media_path
         end
 
         it "should rename an uploaded file in place" do
-          Rails.application.secrets.matterhorn_client_media_path = nil
+          Settings.matterhorn.client_media_path = nil
           expect(subject.file_location).to eq(File.realpath(File.join(File.dirname(tempfile),original)))
         end
 
         it "should copy an uploaded file to the media path" do
-          Rails.application.secrets.matterhorn_client_media_path = media_path
+          Settings.matterhorn.client_media_path = media_path
           expect(subject.working_file_path).to eq(File.join(media_path,original))
         end
       end
@@ -515,12 +515,12 @@ describe MasterFile do
     let(:working_dir) {'/path/to/working_dir/'}
     before do
       ActiveJob::Base.queue_adapter = :test
-      @old_path = Rails.application.secrets.matterhorn_client_media_path
-      Rails.application.secrets.matterhorn_client_media_path= working_dir
+      @old_path = Settings.matterhorn.client_media_path
+      Settings.matterhorn.client_media_path= working_dir
     end
 
     after do
-      Rails.application.secrets.matterhorn_client_media_path = @old_path
+      Settings.matterhorn.client_media_path = @old_path
     end
     describe 'post_processing_working_directory_file_management' do
       it 'enqueues the working directory cleanup job' do


### PR DESCRIPTION
To ease installation, remove the non-secret variable handling from secrets.yml.

The aim, allow configuration to more closely match that of the upstream documentation by removing the the reliance on secrets.yml. 



