### PR TITLE
WIP: fix issues during staging environment spin-up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,6 +137,7 @@ group :test do
   gem 'fakefs', require: 'fakefs/safe'
   gem 'faker'
   gem 'hashdiff'
+  gem 'lograge'
   gem 'poltergeist'
   gem 'rspec-retry'
   gem 'shoulda-matchers'

--- a/Gemfile
+++ b/Gemfile
@@ -144,6 +144,10 @@ group :test do
   gem 'webmock'
 end
 
+group :staging do
+  gem 'lograge'
+end
+
 group :production do
   gem 'google-analytics-rails', '1.1.0'
   gem 'lograge'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,8 +44,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Enable logging to both stdout and file, in more compact format
-  config.logger = Logger.new("| tee -a log/#{Rails.env}.log")
+  # Enable logging to a file with lograge extension (changed 2019-05-07 from both stdout and file
+  config.logger = Logger.new("log/#{Rails.env}.log")
   config.lograge.enabled = true
   config.lograge.custom_options = lambda do |event|
     {:time => event.time}

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -44,8 +44,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Enable logging to both stdout and file, in more compact format
-  config.logger = Logger.new("| tee -a log/#{Rails.env}.log")
+  # Enable logging to a file with lograge extension (changed 2019-05-07 from both stdout and file
+  config.logger = Logger.new("log/#{Rails.env}.log")
   config.lograge.enabled = true
   config.lograge.custom_options = lambda do |event|
     {:time => event.time}

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
+
+  # Enable logging to a file (changed 2019-05-07 from both stdout and file 
+  config.logger = Logger.new("log/#{Rails.env}.log")
+
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,5 +42,9 @@ Rails.application.configure do
 
   # Enable logging to a file (changed 2019-05-07 from both stdout and file 
   config.logger = Logger.new("log/#{Rails.env}.log")
+  config.lograge.enabled = true
+  config.lograge.custom_options = lambda do |event|
+    {:time => event.time}
+  end
 
 end

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -44,8 +44,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Enable logging to both stdout and file, in more compact format
-  config.logger = Logger.new("| tee -a log/#{Rails.env}.log")
+  # Enable logging to a file with lograge extension (changed 2019-05-07 from both stdout and file
+  config.logger = Logger.new("log/#{Rails.env}.log")
   config.lograge.enabled = true
   config.lograge.custom_options = lambda do |event|
     {:time => event.time}


### PR DESCRIPTION
Fixes:
- Ruby 2.5.x: this line fails `Logger.new("| tee -a log/#{Rails.env}.log")` - restrict to file only logging instead of both file log and stdout
- lograge gem missing in GemFile `staging` env section
- align `config/environments/test.rb` with `staging.rb`