### PR TITLE
Add new file management strategy; addresses #447

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ### Added
 
+- New file management strategy to allow retnetion of UI uploaded files in directory named after the collection (similarly to the drop box ingest workflow) [PR #454](https://github.com/ualbertalib/avalon/pull/454)
 - Environment variable based configuration [#415](https://github.com/ualbertalib/avalon/pull/415) and samples [#416](https://github.com/ualbertalib/avalon/pull/416)
 - UofA Libraries splash page theme [#410](https://github.com/ualbertalib/avalon/pull/410), [#411](https://github.com/ualbertalib/avalon/pull/411) & [#412](https://github.com/ualbertalib/avalon/pull/412)
 - batch ingest post-encoding email [#403](https://github.com/ualbertalib/avalon/pull/403)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ### Added
 
-- New file management strategy to allow retnetion of UI uploaded files in directory named after the collection (similarly to the drop box ingest workflow) [PR #454](https://github.com/ualbertalib/avalon/pull/454)
+- New file management strategy to allow retention of UI uploaded files in directory named after the collection (similarly to the drop box ingest workflow) [PR #454](https://github.com/ualbertalib/avalon/pull/454)
+  - Requires the following config to be added/changed to enable 
+    - `SETTINGS__MASTER_FILE_MANAGEMENT__PATH=/path/to/retention/dir`
+    - `SETTINGS__MASTER_FILE_MANAGEMENT__STRATEGY=move-ui-upload-only`
 - Shibboleth authenication (CCID-based) [PR #409](https://github.com/ualbertalib/avalon/pull/409/files)
 - Environment variable based configuration [#415](https://github.com/ualbertalib/avalon/pull/415) and samples [#416](https://github.com/ualbertalib/avalon/pull/416)
 - UofA Libraries splash page theme [#410](https://github.com/ualbertalib/avalon/pull/410), [#411](https://github.com/ualbertalib/avalon/pull/411) & [#412](https://github.com/ualbertalib/avalon/pull/412)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 - New file management strategy to allow retention of UI uploaded files in directory named after the collection (similarly to the drop box ingest workflow) [PR #454](https://github.com/ualbertalib/avalon/pull/454)
   - Requires the following config to be added/changed to enable 
     - `SETTINGS__MASTER_FILE_MANAGEMENT__PATH=/path/to/retention/dir`
-    - `SETTINGS__MASTER_FILE_MANAGEMENT__STRATEGY=move-ui-upload-only`
+    - `SETTINGS__MASTER_FILE_MANAGEMENT__STRATEGY=move_ui_upload_only`
 - Shibboleth authenication (CCID-based) [PR #409](https://github.com/ualbertalib/avalon/pull/409/files)
 - Environment variable based configuration [#415](https://github.com/ualbertalib/avalon/pull/415) and samples [#416](https://github.com/ualbertalib/avalon/pull/416)
 - UofA Libraries splash page theme [#410](https://github.com/ualbertalib/avalon/pull/410), [#411](https://github.com/ualbertalib/avalon/pull/411) & [#412](https://github.com/ualbertalib/avalon/pull/412)

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -724,15 +724,15 @@ class MasterFile < ActiveFedora::Base
     when 'delete'
       MasterFileManagementJobs::Delete.perform_now self.id
     when 'move_ui_upload_only'
-      # check if the MasterFile.file_location contains the `dropbox_directory_name`
+      # check if the MasterFile.file_location contains the collection directory name`
       # If video uploaded via the UI file upload then video stored in temporary upload directory
       # Move to a directory named after the collection
-      dropbox_directory_name = self.media_object.collection.dropbox_directory_name
-      raise '"dropbox_directory_name" missing for master_file_management strategy "move_ui_upload_only"' if dropbox_directory_name.blank?
-      if self.file_location.exclude? dropbox_directory_name
+      collection_directory_name = self.media_object.collection.dropbox_directory_name
+      raise '"path" configuration missing for master_file_management strategy "move_ui_upload_only"' if collection_directory_name.blank?
+      if self.file_location.exclude? collection_directory_name 
         move_path = Settings.master_file_management.path
         raise '"path" configuration missing for master_file_management strategy "move"' if move_path.blank?
-        newpath = File.join(move_path, dropbox_directory_name, MasterFile.post_processing_move_filename(file_location, id: id))
+        newpath = File.join(move_path, collection_directory_name, MasterFile.post_processing_move_filename(file_location, id: id))
         MasterFileManagementJobs::Move.perform_later self.id, newpath
       end
     when 'move'

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -724,9 +724,9 @@ class MasterFile < ActiveFedora::Base
     when 'delete'
       MasterFileManagementJobs::Delete.perform_now self.id
     when 'move-ui-upload-only'
-      # test Admin::Collection object dropbox_directory_name property within 
-      # reflected with the MasterFile locator property
-      # If not then move
+      # check if the MasterFile.file_location contains the `dropbox_directory_name`
+      # If video uploaded via the UI file upload then video stored in temporary upload directory
+      # Move to a directory named after the collection
       dropbox_directory_name = self.media_object.collection.dropbox_directory_name
       raise '"dropbox_directory_name" missing for master_file_management strategy "move-ui-upload-only"' if dropbox_directory_name.blank?
       if self.file_location.exclude? dropbox_directory_name

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -723,12 +723,12 @@ class MasterFile < ActiveFedora::Base
     case Settings.master_file_management.strategy
     when 'delete'
       MasterFileManagementJobs::Delete.perform_now self.id
-    when 'move-ui-upload-only'
+    when 'move_ui_upload_only'
       # check if the MasterFile.file_location contains the `dropbox_directory_name`
       # If video uploaded via the UI file upload then video stored in temporary upload directory
       # Move to a directory named after the collection
       dropbox_directory_name = self.media_object.collection.dropbox_directory_name
-      raise '"dropbox_directory_name" missing for master_file_management strategy "move-ui-upload-only"' if dropbox_directory_name.blank?
+      raise '"dropbox_directory_name" missing for master_file_management strategy "move_ui_upload_only"' if dropbox_directory_name.blank?
       if self.file_location.exclude? dropbox_directory_name
         move_path = Settings.master_file_management.path
         raise '"path" configuration missing for master_file_management strategy "move"' if move_path.blank?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,9 +95,9 @@ services:
       - FCREPO_URL=http://fcrepo:8080/fcrepo/rest
       - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
       - MASTER_FILE_PATH:/masterfiles/upload
-      - MASTER_FILE_STRATEGY=move-ui-upload-only
+      - MASTER_FILE_STRATEGY=move_ui_upload_only
       - SETTINGS__MASTER_FILE_MANAGEMENT__PATH=/masterfiles/upload
-      - SETTINGS__MASTER_FILE_MANAGEMENT__STRATEGY=move-ui-upload-only
+      - SETTINGS__MASTER_FILE_MANAGEMENT__STRATEGY=move_ui_upload_only
       - MATTERHORN_URL=http://matterhorn_system_account:CHANGE_ME@matterhorn:8080/
       - MATTERHORN_CLIENT_MEDIA_PATH=/masterfiles
       - MATTERHORN_SERVER_MEDIA_PATH=/masterfiles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,10 @@ services:
       - EMAIL_SUPPORT
       - FCREPO_URL=http://fcrepo:8080/fcrepo/rest
       - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
-      - MASTER_FILE_PATH
-      - MASTER_FILE_STRATEGY=delete
+      - MASTER_FILE_PATH:/masterfiles/upload
+      - MASTER_FILE_STRATEGY=move-ui-upload-only
+      - SETTINGS__MASTER_FILE_MANAGEMENT__PATH=/masterfiles/upload
+      - SETTINGS__MASTER_FILE_MANAGEMENT__STRATEGY=move-ui-upload-only
       - MATTERHORN_URL=http://matterhorn_system_account:CHANGE_ME@matterhorn:8080/
       - MATTERHORN_CLIENT_MEDIA_PATH=/masterfiles
       - MATTERHORN_SERVER_MEDIA_PATH=/masterfiles

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -327,6 +327,7 @@ describe MasterFile do
         subject {
           mf = MasterFile.new()
           mf.setContent(upload)
+          mf.set_workflow()
           mf.save
           mf
         }
@@ -352,14 +353,15 @@ describe MasterFile do
           Rails.application.secrets.matterhorn_client_media_path = media_path
           expect(subject.working_file_path).to eq(File.join(media_path,original))
         end
-        it "should not disappear after the post_processing_file_management" do
+        it "should not disappear after the post_processing_file_management executes" do
           new_media_object.collection = collection
           subject.media_object = new_media_object
           tmp = Settings.master_file_management.strategy
           Settings.master_file_management.strategy = 'move-ui-upload-only'
           subject.send(:post_processing_file_management)
+          subject.reload
           Settings.master_file_management.strategy = 'none' 
-          expect(subject.file_location.exist?).to be_truthy
+          expect(File.exist?(subject.file_location)).to be_truthy
         end
       end
     end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -356,11 +356,11 @@ describe MasterFile do
         it "should not disappear after the post_processing_file_management executes" do
           new_media_object.collection = collection
           subject.media_object = new_media_object
-          tmp = Settings.master_file_management.strategy
+          @old_strategy = Settings.master_file_management.strategy
           Settings.master_file_management.strategy = 'move-ui-upload-only'
           subject.send(:post_processing_file_management)
           subject.reload
-          Settings.master_file_management.strategy = 'none' 
+          Settings.master_file_management.strategy = @old_strategy
           expect(File.exist?(subject.file_location)).to be_truthy
         end
       end
@@ -469,6 +469,12 @@ describe MasterFile do
     let(:encode) { double("encode", :output => []) }
     before do
       allow(master_file).to receive(:update_ingest_batch).and_return(true)
+      @old_strategy = Settings.master_file_management.strategy
+      Settings.master_file_management.strategy = 'none'
+    end
+
+    after do
+      Settings.master_file_management.strategy = @old_strategy
     end
 
     it 'should set the digitized date' do
@@ -531,11 +537,14 @@ describe MasterFile do
     before do
       ActiveJob::Base.queue_adapter = :test
       @old_path = Rails.application.secrets.matterhorn_client_media_path
+      @old_strategy = Settings.master_file_management.strategy
+      Settings.master_file_management.strategy = 'none'
       Rails.application.secrets.matterhorn_client_media_path= working_dir
     end
 
     after do
       Rails.application.secrets.matterhorn_client_media_path = @old_path
+      Settings.master_file_management.strategy = @old_strategy
     end
     describe 'post_processing_working_directory_file_management' do
       it 'enqueues the working directory cleanup job' do

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -358,7 +358,7 @@ describe MasterFile do
           subject.media_object = new_media_object
           @old_strategy = Settings.master_file_management.strategy
           @old_path = Settings.master_file_management.path
-          Settings.master_file_management.strategy = 'move-ui-upload-only'
+          Settings.master_file_management.strategy = 'move_ui_upload_only'
           Settings.master_file_management.path = media_path
           subject.send(:post_processing_file_management)
           subject.reload

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -357,10 +357,13 @@ describe MasterFile do
           new_media_object.collection = collection
           subject.media_object = new_media_object
           @old_strategy = Settings.master_file_management.strategy
+          @old_path = Settings.master_file_management.path
           Settings.master_file_management.strategy = 'move-ui-upload-only'
+          Settings.master_file_management.path = media_path
           subject.send(:post_processing_file_management)
           subject.reload
           Settings.master_file_management.strategy = @old_strategy
+          Settings.master_file_management.path= @old_path
           expect(File.exist?(subject.file_location)).to be_truthy
         end
       end


### PR DESCRIPTION
Fixes #447 ; refs #448 

Add a new file management strategy to allow retention of UI uploaded files in directory named after the collection (similarly to the drop box ingest workflow)

Details:

UI offers two paths to ingest video file: (1) UI file upload or (2) UI ingest from a drop box 

(1) Ingest from a drop box utilizes a video file previously uploaded to the file system into a directory named after its collection, copies the video into a working directory, creates an active job to process and another job to clean up the working directory. This workflow is specified in part by the property: `master_file_management.strategy = none` [1]. The associated Fedora property that stores the video location: `ebucore:locator         "/tmp/videoshort.mp4"^^<http://www.w3.org/2001/XMLSchema#string> ;`

(2) Ingest via the UI file upload with the `master_file_management.strategy=none` uploads the video via the web browser to the server setting the location of the file to `tmp` (this property is stored within Fedora 
as `ebucore:filename "file:///tmp/videoshort.mp4"^^<http://www.w3.org/2001/XMLSchema#string> ;`). The video is copied to a working directory, an active job created to process and another to clean up the working directory. Also, the uploaded file is removed from the `tmp` upload directory leaving the Fedora location property outdated and no file retained on the server.

A screenshot distinguishing 1 and 2. 

![image](https://user-images.githubusercontent.com/879785/57557884-eb075580-7338-11e9-84b4-cd6123b48c9e.png)


To fix the UI file upload, the proposed solution is to add a new file management strategy, `file management strategy = move-ui-upload-only` which will move the Web UI uploaded file into a safe directory during the `post_processing_file_management` background job. The code checks to see if the `file_location` contains the name of the collection and if not moves the file into the `Settings.master_file_management.path` directory for safe storage and updates the Fedora property with a valid location. This aims to helping to solve both #447 and #448. See [here for details](https://github.com/ualbertalib/avalon/blob/9f037a5f083c2f213d2656e3adc4e8d683b3c716/app/models/master_file.rb#L726-L737)

Setup changes:
- `SETTINGS__MASTER_FILE_MANAGEMENT__PATH=/masterfiles/upload`
- `SETTINGS__MASTER_FILE_MANAGEMENT__STRATEGY=move-ui-upload-only`

The third path is the batch ingest. As of 2019-05-10 not tested.

Other alternatives:
- Alter [MasterFile.setContent](https://github.com/ualbertalib/avalon/blob/9f037a5f083c2f213d2656e3adc4e8d683b3c716/app/models/master_file.rb#L178-L197) to copy the uploaded file to a specified directory. Downside, video file might be large, the above alternative allow the process to run as a background job.

References:
[1] https://wiki.dlib.indiana.edu/display/VarVideo/Managing+Master+Files
[2]
https://github.com/ualbertalib/avalon/blob/9f037a5f083c2f213d2656e3adc4e8d683b3c716/app/models/master_file.rb#L726-L737
[3] https://github.com/ualbertalib/avalon/blob/9f037a5f083c2f213d2656e3adc4e8d683b3c716/app/models/master_file.rb#L178-L197