### PR TITLE
use shibboleth as default and disable user login form in production

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,11 +70,13 @@ encode_throttling:
   update_jobs_spacing: 10
 auth:
   configuration:
-    - :name: Avalon Test Auth
-      :provider: :identity
-      :params:
-        :fields:
-        - :email
+<% if Rails.env.development? || Rails.env.test? %>
+  - :name: Avalon Test Auth
+    :provider: :identity
+    :params:
+      :fields:
+      - :email
+<% end %>
 <% if Rails.application.secrets.lti_auth_key.present? %>
     - :name: Avalon LTI OAuth
       :provider: :lti
@@ -83,3 +85,8 @@ auth:
         :oauth_credentials:
           <%= Rails.application.secrets.lti_auth_key %>: <%= Rails.application.secrets.lti_auth_secret %>
 <% end %>
+<% if Rails.env.staging? || Rails.env.production? %>
+    - :name: Avalon Shibboleth OAuth
+      :provider: :shibboleth
+<% end %>
+


### PR DESCRIPTION
Fixes #issuenumber ; refs #517 #516 #514 #513 

Present tense short summary (50 characters or less)

This is to enable shibboleth authentication as the default in staging/production environment. This change should address the issues mentioned above.  

Changes proposed in this pull request:
* Change in config/settings.yml to add shibboleth as an auth configuration when in production/staging environment

