### PR TITLE
update feature item link on the homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## Table of Contents
 
+- [Unreleased](#Unreleased)
 - [Avalon-6 Production v6.4.3.20190821.uofa](#Production v6.4.3.20190821.uofa)
 - [Avalon-6 Production v6.4.3.20190809.uofa](#Production v6.4.3.20190809.uofa)
 - [Avalon-6 Production v6.4.3.20190709.uofa](#Production v6.4.3.20190709.uofa)
 - [Avalon-6 6.4.3.Unreleased](#Avalon.v6.4.3.Unreleased)
 - [Avalon-6 6.4.2.Unreleased](#Avalon.v6.4.2.Unreleased)
 - [Avalon-5 v5.1.5.20180727](#Avalon-v5.1.5.20180727)
+
+<a name="Unreleased" />
+## Unreleased
+
+### Changed
+- use a direct link to the Feature Item rather than a search avoids needing to be logged-in [#529](https://github.com/ualbertalib/avalon/issues/529)
 
 <a name="Production v6.4.3.20190821.uofa" />
 ## Avalon-6 Production v6.4.3.20190821.uofa

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -31,7 +31,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   </div>
   <div class="col-md-4">
     <h4 class="text-center">Featured Item</h4>
-    <a href='/catalog?q="+An+Evening+with+Edward+Snowden+on+Security%2C+Public+Life+and+Research"' class="embed-responsive embed-responsive-16by9">
+    <a href='media_objects/7h149q366' class="embed-responsive embed-responsive-16by9">
       <%= image_tag "welcome_featured_item.jpg", alt: "Featured Item", class: "embed-responsive-item" %>
       <div class="caption post-content"><h5 class="text-center">An Evening with Edward Snowden</h5></div>
     </a>


### PR DESCRIPTION
Fixes #529

If you were not logged in the search would show a confusing "no results" message. We're replacing the link from the Feature Item as a search to be a direct link to the object which would prompt a user that they need to login in order to view it.
