### PR TITLE
update date_created date_issued links to the EDTF standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## Table of Contents
 
+- [Unreleased](#Unreleased)
 - [Avalon-6 Production v6.4.3.20190821.uofa](#Production v6.4.3.20190821.uofa)
 - [Avalon-6 Production v6.4.3.20190809.uofa](#Production v6.4.3.20190809.uofa)
 - [Avalon-6 Production v6.4.3.20190709.uofa](#Production v6.4.3.20190709.uofa)
 - [Avalon-6 6.4.3.Unreleased](#Avalon.v6.4.3.Unreleased)
 - [Avalon-6 6.4.2.Unreleased](#Avalon.v6.4.2.Unreleased)
 - [Avalon-5 v5.1.5.20180727](#Avalon-v5.1.5.20180727)
+
+<a name="Unreleased" />
+## Unreleased
+
+### Fixed
+- update the links on the edit page to the EDTF standard [#419](https://github.com/ualbertalib/avalon/issues/419)
 
 <a name="Production v6.4.3.20190821.uofa" />
 ## Avalon-6 Production v6.4.3.20190821.uofa

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,13 +85,13 @@ en:
       Creation date should only be used if Date is a re-issue date. Then Creation date
       would contain the original publication date. Enter date information in a format
       consistent with the options shown in <a
-      href="http://www.loc.gov/standards/datetime/pre-submission.html"
+      href="http://www.loc.gov/standards/datetime/edtf.html"
       target="_blank" rel="noopener nofollow">Extended Date/Time Format (EDTF) 1.0</a>.
     date_issued: |
       <strong>Required field.</strong> Date should be the main publication date
       associated with the item to be used for sorting browse and search results.
       Enter date information in a format consistent with the options shown in <a
-      href="http://www.loc.gov/standards/datetime/pre-submission.html"
+      href="http://www.loc.gov/standards/datetime/edtf.html"
       target="_blank" rel="noopener nofollow">Extended Date/Time Format (EDTF) 1.0</a>.
     genre: |
       Genre can be used to categorize an item by form, style, or subject matter. For


### PR DESCRIPTION
Fixes #419

Update date_created date_issued links to the EDTF standard

Was previously linking to the draft specification of the standard.