### PR TITLE
update the feature audio collection on the homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## Table of Contents
 
+- [Unreleased](#Unreleased)
 - [Avalon-6 Production v6.4.3.20190821.uofa](#Production v6.4.3.20190821.uofa)
 - [Avalon-6 Production v6.4.3.20190809.uofa](#Production v6.4.3.20190809.uofa)
 - [Avalon-6 Production v6.4.3.20190709.uofa](#Production v6.4.3.20190709.uofa)
 - [Avalon-6 6.4.3.Unreleased](#Avalon.v6.4.3.Unreleased)
 - [Avalon-6 6.4.2.Unreleased](#Avalon.v6.4.2.Unreleased)
 - [Avalon-5 v5.1.5.20180727](#Avalon-v5.1.5.20180727)
+
+<a name="Unreleased" />
+## Unreleased
+
+### Changed
+- use a public collection for the Featured Video Collection rather than a protected one [#536](https://github.com/ualbertalib/avalon/issues/536)
 
 <a name="Production v6.4.3.20190821.uofa" />
 ## Avalon-6 Production v6.4.3.20190821.uofa

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -24,9 +24,9 @@ Unless required by applicable law or agreed to in writing, software distributed
   </div>
   <div class="col-md-4">
     <h4 class="text-center">Featured Audio Collection</h4>
-    <a href="/catalog?f%5Bavalon_resource_type_ssim%5D%5B%5D=Sound+Recording&f%5Bcollection_ssim%5D%5B%5D=Convocation+Hall+" class="embed-responsive embed-responsive-16by9">
+    <a href="/catalog?f[avalon_resource_type_ssim][]=Sound+Recording&f[collection_ssim][]=Edmonton+Mennonite+Centre+for+Newcomers+(EMCN)" class="embed-responsive embed-responsive-16by9">
       <%= image_tag "welcome_audio_collection.jpg", alt: "Featured Audio Collection", class: "embed-responsive-item"%>
-      <div class="caption post-content"><h5 class="text-center">Convocation Hall Sound Recordings</h5></div>
+      <div class="caption post-content"><h5 class="text-center">Edmonton Mennonite Centre for Newcomers</h5></div>
     </a>
   </div>
   <div class="col-md-4">

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -26,7 +26,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <h4 class="text-center">Featured Audio Collection</h4>
     <a href="/catalog?f[avalon_resource_type_ssim][]=Sound+Recording&f[collection_ssim][]=Edmonton+Mennonite+Centre+for+Newcomers+(EMCN)" class="embed-responsive embed-responsive-16by9">
       <%= image_tag "welcome_audio_collection.jpg", alt: "Featured Audio Collection", class: "embed-responsive-item"%>
-      <div class="caption post-content"><h5 class="text-center">Edmonton Mennonite Centre for Newcomers</h5></div>
+      <div class="caption post-content"><h5 class="text-center">World of Story Collection</h5></div>
     </a>
   </div>
   <div class="col-md-4">


### PR DESCRIPTION
Fixes #536

If you were not logged in the search would show a confusing "no results" message. We're replacing the collection for the Feature Audio Collection with one that has public access.