### PR TITLE
Fixed audio quality selector being cut off on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ## Table of Contents
 
+- [Unreleased](#Unreleased)
 - [Avalon-6 Production v6.4.3.20190821.uofa](#Production v6.4.3.20190821.uofa)
 - [Avalon-6 Production v6.4.3.20190809.uofa](#Production v6.4.3.20190809.uofa)
 - [Avalon-6 Production v6.4.3.20190709.uofa](#Production v6.4.3.20190709.uofa)
 - [Avalon-6 6.4.3.Unreleased](#Avalon.v6.4.3.Unreleased)
 - [Avalon-6 6.4.2.Unreleased](#Avalon.v6.4.2.Unreleased)
 - [Avalon-5 v5.1.5.20180727](#Avalon-v5.1.5.20180727)
+
+<a name="Unreleased" />
+## Unreleased
+
+### Fixed
+- Fixed audio quality selector being cut off on mobile by opening selector downwards [#531](https://github.com/ualbertalib/avalon/issues/531)
 
 <a name="Production v6.4.3.20190821.uofa" />
 ## Avalon-6 Production v6.4.3.20190821.uofa

--- a/app/assets/stylesheets/era_custom.scss
+++ b/app/assets/stylesheets/era_custom.scss
@@ -16,3 +16,12 @@ div.terms-of-use-custom {
   margin-left: 30px;
   margin-right: 30px;
 }
+
+.mejs__audio .mejs__qualities-selector {
+  position: static;
+  margin-top: 40px;
+  @media (min-width: 768px) {
+    position: absolute;
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
- Quality selector now opens downward on mobile for audio

Fixes #531

before
![Screenshot from 2019-09-05 17-06-48](https://user-images.githubusercontent.com/14242562/64389414-ccbc1880-cfff-11e9-99d7-0bc69e164891.png)
after
![Screenshot from 2019-09-05 17-05-56](https://user-images.githubusercontent.com/14242562/64389416-cd54af00-cfff-11e9-9855-0e551bc14fac.png)

