### PR TITLE
Update audio waveform gem to 2.0.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,8 +222,8 @@ GEM
     api-pagination (4.8.2)
     arel (9.0.0)
     ast (2.4.0)
-    audio_waveform-ruby (1.0.6)
-      json (~> 2.1.0)
+    audio_waveform-ruby (1.0.7)
+      json (~> 2.3)
     autoprefixer-rails (9.7.4)
       execjs
     aws-eventstream (1.0.3)


### PR DESCRIPTION
* update audio_waveform to update its json dependency to 2.3