### PR TITLE
fix timeout for large ">13GB" files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 ### Unreleased
 
+#### Fixed
+
+- Add ability to change timeout of transcoding (Matterhorn) for master files 13GB or greater. Addresses [#650](https://github.com/ualbertalib/avalon/issues/650). Note: not needed in Avalon v7.1 due to code refactoring around transcoding (i.e., replacement of Matterhorn).
+
 <a name="Production.v6.5.0.20200528.uofa" />
 
 ### Avalon-6 Production v6.5.0.20200528.uofa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and releases in Jupiter project adheres to [Semantic Versioning](http://semver.o
 
 #### Fixed
 
-- Add ability to change timeout of transcoding (Matterhorn) for master files 13GB or greater. Addresses [#650](https://github.com/ualbertalib/avalon/issues/650). Note: not needed in Avalon v7.1 due to code refactoring around transcoding (i.e., replacement of Matterhorn).
+- Add ability to change timeout of transcoding (Matterhorn) for master files 13GB or greater via environment variable: `AVALON_MATTERHORN_TIMEOUT`. Addresses [#650](https://github.com/ualbertalib/avalon/issues/650). Note: not needed in Avalon v7.1 due to code refactoring around transcoding (i.e., replacement of Matterhorn).
 
 <a name="Production.v6.5.0.20200528.uofa" />
 

--- a/README_CONFIG.md
+++ b/README_CONFIG.md
@@ -52,6 +52,10 @@ Other parameters:
   - `MATTERHORN_CLIENT_MEDIA_PATH` E.G., MATTERHORN_CLIENT_MEDIA_PATH=/masterfiles
   - `MATTERHORN_SERVER_MEDIA_PATH` E.G., MATTERHORN_SERVER_MEDIA_PATH=./masterfiles
 
+- UofA Lib [PR #651](https://github.com/ualbertalib/avalon/pull/651/files) allowing an increase in the timeout when Avalon communicates with Matterhorn (default is HTTP::NET 30sec); required for large master files ~13GB or larger
+  - `AVALON_MATTERHORN_TIMEOUT` E.G., AVALON_MATTERHORN_TIMEOUT=120
+
+
 ### Redis
 
 [Redis](https://github.com/redis/redis-rb): set environment valiable `REDIS_URL`. E.G., REDIS_URL=redis://localhost:6379'

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 
 # Lengthen timeout in Net::HTTP
+# Todo: not needed in Avalon v7.1
 module Net
     class HTTP
     alias old_initialize initialize

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,14 +1,12 @@
-require 'net/http'
-
-# Lengthen timeout in Net::HTTP
+# Lengthen timeout when executing REST API calls via rubyhorn (to Matterhorn) overriding
+# https://github.com/avalonmediasystem/rubyhorn/blob/avalon-r6/lib/rubyhorn/rest_client/common.rb#L8
 # Todo: not needed in Avalon v7.1
-module Net
-    class HTTP
-    alias old_initialize initialize
+module Rubyhorn::RestClient
+  module Common
 
-        def initialize(*args)
-            old_initialize(*args)
-            @read_timeout = ENV['AVALON_NET_HTTP_READ_TIMEOUT'].to_i if ENV['AVALON_NET_HTTP_READ_TIMEOUT']
-        end
+    def connect
+      super.connect
+      @client.open_timeout =  ENV['AVALON_MATTERHORN_TIMEOUT'].to_i if ENV['AVALON_MATTERHORN_TIMEOUT']
     end
+  end
 end

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,0 +1,13 @@
+require 'net/http'
+
+# Lengthen timeout in Net::HTTP
+module Net
+    class HTTP
+    alias old_initialize initialize
+
+        def initialize(*args)
+            old_initialize(*args)
+            @read_timeout = ENV['AVALON_NET_HTTP_READ_TIMEOUT'].to_i if ENV['AVALON_NET_HTTP_READ_TIMEOUT']
+        end
+    end
+end

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,5 +1,9 @@
-# Lengthen timeout when executing REST API calls via rubyhorn (to Matterhorn) overriding
+# Lengthen timeout when executing ingest REST API calls via rubyhorn gem (to the Matterhorn service) overriding Rubyhorn::RestClient::Common `connect`
 # https://github.com/avalonmediasystem/rubyhorn/blob/avalon-r6/lib/rubyhorn/rest_client/common.rb#L8
+# Note: using `super.connect` to leave the origin `connect` as is. The reasoning:
+# a) `login` timeout shouldn't be extended as it opens a denial of service opportunity,
+# b) if `login` fails the active job is retried (https://github.com/avalonmediasystem/avalon/blob/v6.5.0/app/jobs/active_encode_job.rb#L40), and
+# c) the timeouts occur in `addMediaPackage and addMediaPackageUrl` (https://github.com/avalonmediasystem/rubyhorn/blob/master/lib/rubyhorn/rest_client/ingest.rb#L22-L40) and not the `login` method
 # Todo: not needed in Avalon v7.1
 module Rubyhorn::RestClient
   module Common

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       - APP_NAME=avalon
       - ASSET_HOST=http://localhost:3000
       - AVALON_BRANCH=develop
+      - AVALON_NET_HTTP_READ_TIMEOUT=600
       - SETTINGS__DOMAIN=http://localhost:3000
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
       - DATABASE_URL=mysql2://root:mysecretpassword@db:3306/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       - APP_NAME=avalon
       - ASSET_HOST=http://localhost:3000
       - AVALON_BRANCH=develop
-      - AVALON_NET_HTTP_READ_TIMEOUT=600
+      - AVALON_MATTERHORN_TIMEOUT=60
       - SETTINGS__DOMAIN=http://localhost:3000
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
       - DATABASE_URL=mysql2://root:mysecretpassword@db:3306/

--- a/environment_ansible_vars.sample
+++ b/environment_ansible_vars.sample
@@ -14,7 +14,8 @@ MATTERHORN_URL: 'http://matterhorn_system_account:{password}@{host}:4080/'
 # UofA Lib pr allowing client and server contexts to have different paths
 MATTERHORN_CLIENT_MEDIA_PATH: '/masterfiles'
 MATTERHORN_SERVER_MEDIA_PATH: '/masterfiles'
- 
+AVALON_MATTERHORN_TIMEOUT: '120'
+
 # Redis Gem: see for details
 REDIS_URL: 'redis://localhost:6379'
  

--- a/environment_passengerfile.json.sample
+++ b/environment_passengerfile.json.sample
@@ -1,4 +1,5 @@
 {
+  "AVALON_MATTERHORN_TIMEOUT":"120",
   "DATABASE_URL":"mysql2://{username}:{password}@localhost:3306/rails?pool=5&timeout=5000",
   "FEDORA_URL":"http://{username}:{password}@localhost:8984/fedora/rest/prod",
   "FEDORA_BASE_PATH":"/prod"                                         


### PR DESCRIPTION
Addresses #650

When batch ingesting large files, (e.g., 13GB), the UI reports a "Timed out" error. This PR allows lengthening the timeout beyond the default. The timeout is a rest_client call (activeencode and rubyhorn Gems) that queues a job with the transcoding service (Matterhorn). The gems don't seem to support setting the timeout as a option that will flow from Avalon, through, activeencode and rubyhorn Gems to the rest_client. Mitigating factor, the problem disappears in Avalon v7.1 (we are on v6.5).

* adds timeout env var to increase read timeout beyond default